### PR TITLE
Use nucleus colors

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,9 +14,12 @@
  *= require_self
  */
 
-:root {
+.mds {
   --primary: #430098;
   --mds-text-btn-text: var(--primary);
+  --mds-bg-btn-text-focus: #e5def2;
+  --mds-bg-btn-text-hover: #eee8f6;
+  --mds-border-search-focus: var(--primary);
 }
 body {
   margin: 0;


### PR DESCRIPTION
Overriding some of the default mds colors with nucleus colors.  Targeting `.mds` instead of `:root` for specificity.