### PR TITLE
OT-45 - Implement widget panel drag sorting, etc.

### DIFF
--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -26,7 +26,7 @@
     </a>
     <div class="actions flex items-center">
       <% unless @library_mode %>
-        <button class="menu-button flex items-center cursor-pointer">
+        <button class="menu-button flex items-center cursor-pointer" aria-label="Open menu">
           <span class="icon icon-dots-three-vertical"></span>
         </button>
         <mx-menu>

--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -112,13 +112,13 @@ if (menu && menuButton) menu.anchorEl = menuButton;
 const menuItems = root.querySelectorAll("mx-menu-item");
 if (menuItems.length) {
 
-  menuItems[1].addEventListener("click", () => {
+  menuItems[0].addEventListener("click", () => {
     window.parent.postMessage(
       { type: "MODIFY_SETTINGS", payload: {} },
       "*"
     );
   });
-  menuItems[2].addEventListener("click", () => {
+  menuItems[1].addEventListener("click", () => {
     window.parent.postMessage(
       { type: "REMOVE", payload: {} },
       "*"

--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -1,6 +1,6 @@
 <link rel="stylesheet" type="text/css" href="/assets/hurdlr/style.css">
 
-<div data-widget="hurdlr" class="hurdlr inline-widget relative flex flex-col border text-primary shadow-3 rounded-lg overflow-hidden m-8">
+<div class="hurdlr inline-widget relative flex flex-col border bg-white text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
     <p role="heading" aria-level="1" class="my-0 subtitle3">
       Profit + Loss

--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -56,7 +56,8 @@ const tbody = root.querySelector('tbody');
 // Generate the table rows
 rows.forEach(row => {
   const tr = document.createElement('tr');
-  const percent = row.value / <%= @data[:revenue] %> * 100;
+  let percent = row.value / <%= @data[:revenue] %> * 100;
+  if (isNaN(percent)) percent = 0;
   tr.innerHTML = `
     <td aria-labelledby="metric-heading" id="${row.key}-label">
       <div class="relative bg-bar overflow-hidden rounded h-32">

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -5,7 +5,7 @@
 <%# Inline Widget %>
 <div class="list_trac inline-widget relative flex flex-col border text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
-    <p role="heading" aria-level="1" class="my-0 subtitle3">
+    <p role="heading" aria-level="2" class="my-0 subtitle3">
       Online Activity
     </p>
   </header>
@@ -37,10 +37,10 @@
     </a>
     <div class="actions flex items-center space-x-8">
       <% unless @library_mode %>
-        <button class="expand-button flex items-center cursor-pointer">
+        <button class="expand-button flex items-center cursor-pointer" aria-label="Expand widget">
           <span class="icon icon-grow"></span>
         </button>
-        <button class="menu-button flex items-center cursor-pointer">
+        <button class="menu-button flex items-center cursor-pointer" aria-label="Open menu">
           <span class="icon icon-dots-three-vertical"></span>
         </button>
         <mx-menu>

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -3,7 +3,7 @@
 
 <% unless current_page?(component_named_expanded_path('list_trac')) %>
 <%# Inline Widget %>
-<div data-widget="list_trac" class="list_trac inline-widget relative flex flex-col border text-primary shadow-3 rounded-lg overflow-hidden m-8">
+<div class="list_trac inline-widget relative flex flex-col border text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
     <p role="heading" aria-level="1" class="my-0 subtitle3">
       Online Activity

--- a/app/components/widget_panel/widget_panel_component.html.erb
+++ b/app/components/widget_panel/widget_panel_component.html.erb
@@ -11,12 +11,6 @@
     Activate the reorder button and use the arrow keys to reorder the list. Press Escape or Tab to cancel the reordering.
   </p>
   <ol class="widget-grid" aria-labelledby="widgets-heading">
-    <li data-widget="list_trac">
-      <%= render ListTrac::ListTracComponent.new %>
-    </li>
-    <li data-widget="list_trac">
-      <%= render ListTrac::ListTracComponent.new %>
-    </li>
     <% @user_widgets.each do |widget| %>
       <li data-widget="<%= widget %>"><%= render Object.const_get("#{widget.camelize}::#{widget.camelize}Component").new %></li>
     <% end %>

--- a/app/components/widget_panel/widget_panel_component.html.erb
+++ b/app/components/widget_panel/widget_panel_component.html.erb
@@ -4,14 +4,23 @@
 <%# Inline Widget (My Widgets) %>
 <section class="widget_panel text-primary">
   <header class="flex items-center justify-between px-8">
-    <p role="heading" aria-level="1" class="my-0 subtitle2">My Widgets</p>
+    <p id="widgets-heading" role="heading" aria-level="1" class="my-0 subtitle2">My Widgets</p>
     <mx-button btn-type="text" icon="icon icon-plus-circle">Add</mx-button>
   </header>
-  <div class="widget-grid">
+  <p id="reorder-help" class="sr-only">
+    Activate the reorder button and use the arrow keys to reorder the list. Press Escape or Tab to cancel the reordering.
+  </p>
+  <ol class="widget-grid" aria-labelledby="widgets-heading">
+    <li data-widget="list_trac">
+      <%= render ListTrac::ListTracComponent.new %>
+    </li>
+    <li data-widget="list_trac">
+      <%= render ListTrac::ListTracComponent.new %>
+    </li>
     <% @user_widgets.each do |widget| %>
-      <%= render Object.const_get("#{widget.camelize}::#{widget.camelize}Component").new %>
+      <li data-widget="<%= widget %>"><%= render Object.const_get("#{widget.camelize}::#{widget.camelize}Component").new %></li>
     <% end %>
-  </div>
+  </ol>
 </section>
 
 <%# Inline Widget Script (My Widgets) %>
@@ -23,21 +32,219 @@ const root = document.querySelector('.widget_panel');
 const resizeObserver = new ResizeObserver(entries => {
   const height = entries[0].contentRect.height;
   window.parent.postMessage(
-    { type: "RESIZE", payload: { id: 'widget_panel', height } },
-    "*"
+    { type: 'RESIZE', payload: { id: 'widget_panel', height } },
+    '*'
   );
 });
 resizeObserver.observe(root);
 
-const addButton = root.querySelector("mx-button");
+const addButton = root.querySelector('mx-button');
 if (addButton) {
-  addButton.addEventListener("click", () => {
+  addButton.addEventListener('click', () => {
     const url = `${window.location.origin}<%= component_named_expanded_path %>`;
-    window.parent.postMessage(
-      { type: "EXPAND", payload: { url } },
-      "*"
-    );
+    window.parent.postMessage({ type: 'EXPAND', payload: { url } }, '*');
   });
+}
+
+// Drag sorting
+
+const KEYBOARD_DRAG_CLASSES = ['transform', '-translate-y-10'];
+const MOUSE_DRAG_CLASSES = ['z-50', 'pointer-events-none'];
+const dragHandleHtml = widget => `
+  <div class="touch-drag-handle mr-10">
+    <button
+      class="keyboard-drag-button flex pointer-events-none"
+      aria-describedby="reorder-help"
+      aria-label="Reorder ${widget}"
+    >
+      <span class="icon icon-drag"></span>
+    </button>
+  </div>`;
+let draggedWidget; // Widget being dragged
+let overWidget; // Widget being dragged over
+let offsetX, offsetY; // Pointer offset from top left of widget when dragging started
+
+// Add drag handles and event listeners
+const widgets = root.querySelectorAll('li');
+widgets.forEach((widget, i) => {
+  const header = widget.querySelector('header');
+  header.insertAdjacentHTML(
+    'afterbegin',
+    dragHandleHtml(widget.dataset.widget)
+  );
+  header.classList.add('cursor-move');
+  widget.addEventListener('mousedown', onPointerDown);
+  widget.addEventListener('touchstart', onPointerDown);
+  widget.addEventListener('mouseover', onMouseOver);
+  const keyboardDragButton = widget.querySelector('.keyboard-drag-button');
+  keyboardDragButton.addEventListener('keydown', onKeyDown);
+});
+resetWidgetOrderAttributes();
+
+function onPointerDown(e) {
+  let handle =
+    e.type === 'mousedown'
+      ? e.target.closest('header')
+      : e.target.closest('.touch-drag-handle');
+  if (!handle) return; // Do not drag unless dragging by the drag handle
+  e.preventDefault();
+  draggedWidget = e.target.closest('li');
+  draggedWidget.classList.add(...MOUSE_DRAG_CLASSES);
+  const { clientX, clientY } = getPointer(e);
+  offsetX = clientX - draggedWidget.offsetLeft;
+  offsetY = clientY - draggedWidget.offsetTop;
+  window.addEventListener('mousemove', onPointerMove);
+  window.addEventListener('touchmove', onPointerMove);
+  window.addEventListener('mouseup', onPointerUp);
+  window.addEventListener('touchend', onPointerUp);
+}
+
+function onMouseOver(e) {
+  if (!draggedWidget || e.buttons === 0) return; // Only drag if mouse is down
+  e.preventDefault();
+  visuallyReorder(e.target.closest('li'));
+}
+
+function onPointerMove(e) {
+  if (!draggedWidget) return;
+  const rect = draggedWidget.getBoundingClientRect();
+  const { clientX, clientY } = getPointer(e);
+  const x = clientX - draggedWidget.offsetLeft - offsetX;
+  const y = clientY - draggedWidget.offsetTop - offsetY;
+  draggedWidget.style.transform = `translate(${x}px, ${y}px)`;
+  if (e.type === 'touchmove') {
+    // Since there is no mouseover event for touch, we need to check for element using elementFromPoint
+    const target = document.elementFromPoint(clientX, clientY);
+    if (!target) return;
+    const targetWidget = target.closest('li');
+    if (targetWidget) visuallyReorder(targetWidget);
+  }
+}
+
+function onPointerUp(e) {
+  if (!draggedWidget) return;
+  draggedWidget.style.transform = '';
+  draggedWidget.classList.remove(...MOUSE_DRAG_CLASSES);
+  reorderWidgetElements();
+  draggedWidget = null;
+  window.removeEventListener('mousemove', onPointerMove);
+  window.removeEventListener('touchmove', onPointerMove);
+  window.addEventListener('mouseup', onPointerUp);
+  window.addEventListener('touchend', onPointerUp);
+  // TODO: Persist new order
+}
+
+function onKeyDown(e) {
+  if (['Enter', ' '].includes(e.key)) {
+    if (draggedWidget) return keyboardDrop(e);
+    return keyboardPickUp(e);
+  }
+  if (!draggedWidget) return;
+  if (['Tab', 'Escape'].includes(e.key)) return keyboardCancel();
+  if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+    return keyboardMove(e);
+  }
+}
+
+function keyboardPickUp(e) {
+  e.preventDefault();
+  draggedWidget = e.target.closest('li');
+  document.activeElement.setAttribute('aria-pressed', 'true');
+  draggedWidget.classList.add(...KEYBOARD_DRAG_CLASSES);
+}
+
+function keyboardMove(e) {
+  e.preventDefault();
+  const order = getOrder(draggedWidget);
+  const widgets = Array.from(root.querySelectorAll('li')).sort(
+    (a, b) => getOrder(a) - getOrder(b)
+  );
+  if (['ArrowUp', 'ArrowLeft'].includes(e.key) && order !== 0) {
+    visuallyReorder(widgets[order - 1]);
+  } else if (
+    ['ArrowDown', 'ArrowRight'].includes(e.key) &&
+    order !== widgets.length - 1
+  ) {
+    visuallyReorder(widgets[order + 1]);
+  }
+}
+
+function keyboardCancel() {
+  overWidget = null;
+  keyboardDrop();
+}
+
+function keyboardDrop(e) {
+  if (!draggedWidget) return;
+  if (e) e.preventDefault();
+  draggedWidget.classList.remove(...KEYBOARD_DRAG_CLASSES);
+  reorderWidgetElements();
+  document.activeElement.setAttribute('aria-pressed', 'false');
+  draggedWidget = null;
+}
+
+function visuallyReorder(newOverWidget) {
+  // Safari is slow to update the DOM, so while dragging, we only update the CSS order attribute.
+  // This also allows us to cancel keyboard dragging by simply reverting the order attributes.
+  overWidget = newOverWidget;
+  root.querySelectorAll('li').forEach(widget => {
+    if (widget === draggedWidget) widget.dataset.order = getOrder(overWidget);
+    else if (getOrder(overWidget) > getOrder(draggedWidget)) {
+      if (
+        getOrder(widget) > getOrder(draggedWidget) &&
+        getOrder(widget) <= getOrder(overWidget)
+      ) {
+        widget.dataset.order = getOrder(widget) - 1;
+      }
+    } else {
+      if (
+        getOrder(widget) < getOrder(draggedWidget) &&
+        getOrder(widget) >= getOrder(overWidget)
+      ) {
+        widget.dataset.order = getOrder(widget) + 1;
+      }
+    }
+  });
+  // Apply the new order attributes using the dataset values set above
+  root.querySelectorAll('li').forEach(widget => {
+    widget.style.order = widget.dataset.order;
+    widget.removeAttribute('data-order');
+  });
+}
+
+function reorderWidgetElements() {
+  const focused = document.activeElement;
+  if (overWidget && getOrder(draggedWidget) !== getIndex(draggedWidget)) {
+    const orderedWidgets = Array.from(root.querySelectorAll('li')).sort(
+      (a, b) => getOrder(a) - getOrder(b)
+    );
+    orderedWidgets.forEach(widget => draggedWidget.parentElement.appendChild(widget));
+    overWidget = null;
+  }
+  resetWidgetOrderAttributes();
+  focused.focus(); // Keep focus on the keyboard-drag-button
+}
+
+function resetWidgetOrderAttributes() {
+  root.querySelectorAll('li').forEach((widget, i) => {
+    widget.style.order = i;
+  });
+}
+
+function getOrder(el) {
+  return parseInt(el.style.order || 0);
+}
+
+function getIndex(el) {
+  return Array.from(root.querySelectorAll('li')).indexOf(el);
+}
+
+function getPointer(e) {
+  if (e.type === 'touchstart' || e.type === 'touchmove') {
+    return e.touches[0];
+  } else {
+    return e;
+  }
 }
 </script>
 


### PR DESCRIPTION
## Description

- Implemented drag sorting (for mouse, touch, keyboard, and screen readers).
- Fixed a hurdlr divide-by-zero bug when the income is zero.
- Fixed hurdlr menu item exceptions now that there are only two menu items.
- Fixed a few a11y issues.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-45

## Validation Steps
- Verify that widgets rearrange correctly when dragging and dropping.  Using touch, the drag handle is the icon only; using a mouse, the entire header is the drag handle.
- Verify that widgets rearrange correctly when using the keyboard.  Press Enter or Space to pick up a widget, and then press Enter or Space to drop it.  Pressing Escape or Tab cancels reordering.


[OT-45]: https://moxiworks.atlassian.net/browse/OT-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ