### PR TITLE
Update widgets for admin preview functionality

### DIFF
--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -2,7 +2,7 @@
 
 <div class="hurdlr inline-widget relative flex flex-col border bg-white text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
-    <p role="heading" aria-level="1" class="my-0 subtitle3">
+    <p id="heading" role="heading" aria-level="1" class="my-0 subtitle3">
       Profit + Loss
     </p>
   </header>
@@ -21,9 +21,13 @@
   <footer
     class="flex items-center min-h-48 justify-between bg-white border-t px-16"
   >
-    <a href="https://prod-integration.hurdlr.com/saml/assertion/stellar">
-      <img src="/assets/hurdlr/logo.png" width="64" height="30" alt="Hurdlr" />
-    </a>
+    <% unless @library_mode %>
+      <a href="https://prod-integration.hurdlr.com/saml/assertion/stellar">
+    <% end %>
+    <img id="logo" src="/assets/hurdlr/logo.png" width="64" height="30" alt="Hurdlr" />
+    <% unless @library_mode %>
+      </a>
+    <% end %>
     <div class="actions flex items-center">
       <% unless @library_mode %>
         <button class="menu-button flex items-center cursor-pointer" aria-label="Open menu">
@@ -125,4 +129,13 @@ if (menuItems.length) {
     );
   });
 }
+
+window.addEventListener("message", (e) => {
+  if (e.data.type === "UPDATE_PREVIEW") {
+    const { heading, logo } = e.data.payload;
+    if (heading) root.querySelector("#heading").innerText = heading;
+    if (!root.querySelector("#logo").dataset.src) root.querySelector("#logo").dataset.src = root.querySelector("#logo").src;
+    root.querySelector("#logo").src = logo || root.querySelector("#logo").dataset.src;
+  }
+});
 </script>

--- a/app/components/hurdlr/hurdlr_component.rb
+++ b/app/components/hurdlr/hurdlr_component.rb
@@ -6,6 +6,7 @@ class Hurdlr::HurdlrComponent < ViewComponent::Base
   end
 
   def before_render
+    @library_mode ||= params[:library_mode]
     @data = @library_mode ? demo_data : user_vitals
   end
 

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -5,7 +5,7 @@
 <%# Inline Widget %>
 <div class="list_trac inline-widget relative flex flex-col border text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
-    <p role="heading" aria-level="2" class="my-0 subtitle3">
+    <p id="heading" role="heading" aria-level="2" class="my-0 subtitle3">
       Online Activity
     </p>
   </header>
@@ -32,9 +32,13 @@
   <footer
     class="flex items-center min-h-48 justify-between bg-white border-t px-16"
   >
-    <a href="https://stellar.sso.listtrac.com/Account/SingleSignOn">
-      <img src="/assets/list_trac/logo.png" width="64" height="30" alt="ListTrac" />
-    </a>
+    <% unless @library_mode %>
+      <a href="https://stellar.sso.listtrac.com/Account/SingleSignOn">
+    <% end %>
+    <img id="logo" src="/assets/list_trac/logo.png" width="64" height="30" alt="ListTrac" />
+    <% unless @library_mode %>
+      </a>
+    <% end %>
     <div class="actions flex items-center space-x-8">
       <% unless @library_mode %>
         <button class="expand-button flex items-center cursor-pointer" aria-label="Expand widget">
@@ -86,6 +90,15 @@ if (menuItems.length) {
     );
   });
 }
+
+window.addEventListener("message", (e) => {
+  if (e.data.type === "UPDATE_PREVIEW") {
+    const { heading, logo } = e.data.payload;
+    if (heading) root.querySelector("#heading").innerText = heading;
+    if (!root.querySelector("#logo").dataset.src) root.querySelector("#logo").dataset.src = root.querySelector("#logo").src;
+    root.querySelector("#logo").src = logo || root.querySelector("#logo").dataset.src;
+  }
+});
 </script>
 
 <% else %>

--- a/app/components/list_trac/list_trac_component.rb
+++ b/app/components/list_trac/list_trac_component.rb
@@ -7,6 +7,7 @@ class ListTrac::ListTracComponent < ViewComponent::Base
 
   # rubocop:disable Metrics/MethodLength
   def before_render
+    @library_mode ||= params[:library_mode]
     @token = token # TODO: Remove once API is working for us
     @listings = @library_mode ? demo_listings : agent_listings
   end


### PR DESCRIPTION
## Description

Updated widgets to support the admin preview functionality:
  - Widgets can now be set to library mode (demo data, no menu) via a query param.
  - The widget heading and logo can be changed in realtime via postmessage.
  - The logo link is now removed in library mode.

Also, I do think we should factor out a lot of this repeated code at some point, but I'm going to keep kicking that can down the road a bit longer until designs/requirements feel more nailed down.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-50
https://www.figma.com/file/S5TevaRcPuPa6wJNZePI5K/Widgets?node-id=1954%3A126044&t=opnMGU01ZDdgTyQK-0

Admin form is coming along nicely btw.  A nucleus PR will probably be along soon...

![image](https://user-images.githubusercontent.com/3342530/211082435-c838dd25-58ca-4364-bc93-456d6bd278a0.png)
