### PR TITLE
OT-44 - Add list_trac settings modal

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,10 +18,15 @@
   --primary: #430098;
   --secondary: #00bcda;
   --mds-text-btn-text: var(--primary);
+  --mds-bg-btn-contained: var(--primary);
+  --mds-bg-btn-contained-focus: #602fa1;
+  --mds-bg-btn-contained-hover: var(--primary);
+  --mds-bg-btn-contained-active: var(--primary);
   --mds-bg-btn-text-focus: #e5def2;
   --mds-bg-btn-text-hover: #eee8f6;
   --mds-border-search-focus: var(--primary);
   --mds-ripple-btn-text: rgba(67, 0, 152, 0.16);
+  --mds-text-link: var(--primary);
 }
 body {
   margin: 0;
@@ -49,4 +54,10 @@ body {
 }
 .actions button {
   color: var(--primary) !important;
+}
+@media (min-width: 640px) {
+  .settings-inner {
+    width: 26.25rem;
+    height: 17.75rem;
+  }
 }

--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -3,7 +3,7 @@
 <div class="hurdlr inline-widget relative flex flex-col border bg-white text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
     <p id="heading" role="heading" aria-level="1" class="my-0 subtitle3">
-      Profit + Loss
+      <%= @heading %>
     </p>
   </header>
   <div class="flex-1 subtitle4 p-16">

--- a/app/components/hurdlr/hurdlr_component.rb
+++ b/app/components/hurdlr/hurdlr_component.rb
@@ -8,6 +8,7 @@ class Hurdlr::HurdlrComponent < ViewComponent::Base
   def before_render
     @library_mode ||= params[:library_mode]
     @data = @library_mode ? demo_data : user_vitals
+    @heading = "Profit + Loss"
   end
 
   def user_vitals

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -157,7 +157,11 @@ const sendCloseMessage = () => {
   );
 }
 const modal = root.querySelector("mx-modal");
-setTimeout(() => modal.isOpen = true, 400);
+const observer = new MutationObserver(mutations => {
+  requestAnimationFrame(() => modal.isOpen = true);
+  observer.disconnect();
+})
+observer.observe(root, { subtree: true, childList: true });
 modal.addEventListener("mxClose", sendCloseMessage);
 /* We have to recreate the close button since we are overriding the default content of the 
 /* header-right slot. */
@@ -225,7 +229,11 @@ const sendCloseMessage = () => {
   );
 }
 const modal = root.querySelector("mx-modal");
-setTimeout(() => modal.isOpen = true, 400);
+const observer = new MutationObserver(mutations => {
+  requestAnimationFrame(() => modal.isOpen = true);
+  observer.disconnect();
+})
+observer.observe(root, { subtree: true, childList: true });
 modal.addEventListener("mxClose", sendCloseMessage);
 
 /* The close-on-escape behavior provided by mx-modal does not work in an iframe. */

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -1,12 +1,12 @@
 <!-- Token: <%= @token %> -->
 <link rel="stylesheet" type="text/css" href="/assets/list_trac/style.css">
 
-<% unless current_page?(component_named_expanded_path('list_trac')) %>
+<% if current_page?(component_named_default_path('list_trac')) %>
 <%# Inline Widget %>
 <div class="list_trac inline-widget relative flex flex-col border text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
     <p id="heading" role="heading" aria-level="2" class="my-0 subtitle3">
-      Online Activity
+      <%= @heading %>
     </p>
   </header>
   <div class="flex-1 p-16 bg-gray">
@@ -101,60 +101,49 @@ window.addEventListener("message", (e) => {
 });
 </script>
 
-<% else %>
+<% elsif current_page?(component_named_expanded_path('list_trac')) %>
 
 <%# Expanded Widget %>
 <div class="list_trac w-screen h-screen">
   <mx-modal large close-on-escape="false">
-    <div slot="header-left">Online Activity</div>
+    <div slot="header-left"><%= @heading %></div>
     <div slot="header-right" class="flex items-center space-x-16">
-      <mx-search flat dense placeholder="Search"></mx-search>
+      <mx-icon-button href="<%= component_named_settings_path %>" icon="text-link mds-gear"></mx-icon-button>
       <mx-button class="close-button" btn-type="text">Close</mx-button>
     </div>
     <mx-table>
       <div>
         <mx-table-row>
           <mx-table-cell>123 Main St</mx-table-cell>
-          <mx-table-cell>Pending</mx-table-cell>
           <mx-table-cell>100</mx-table-cell>
           <mx-table-cell>10</mx-table-cell>
-          <mx-table-cell>
-            <mx-button btn-type="text" icon="icon icon-visibility">Preview</mx-button>
-            <mx-button btn-type="text" icon="icon icon-event">Schedule Report</mx-button>
-          </mx-table-cell>
+          <mx-table-cell></mx-table-cell>
         </mx-table-row>
         <mx-table-row>
           <mx-table-cell>456 Main St</mx-table-cell>
-          <mx-table-cell>Pending</mx-table-cell>
           <mx-table-cell>200</mx-table-cell>
           <mx-table-cell>20</mx-table-cell>
-          <mx-table-cell>
-            <mx-button btn-type="text" icon="icon icon-visibility">Preview</mx-button>
-            <mx-button btn-type="text" icon="icon icon-event">Schedule Report</mx-button>
-          </mx-table-cell>
+          <mx-table-cell></mx-table-cell>
         </mx-table-row>
         <mx-table-row>
           <mx-table-cell>789 Main St</mx-table-cell>
-          <mx-table-cell>Pending</mx-table-cell>
           <mx-table-cell>300</mx-table-cell>
           <mx-table-cell>30</mx-table-cell>
-          <mx-table-cell>
-            <mx-button btn-type="text" icon="icon icon-visibility">Preview</mx-button>
-            <mx-button btn-type="text" icon="icon icon-event">Schedule Report</mx-button>
-          </mx-table-cell>
+          <mx-table-cell></mx-table-cell>
         </mx-table-row>
         <mx-table-row>
           <mx-table-cell>101 Main St</mx-table-cell>
-          <mx-table-cell>Pending</mx-table-cell>
           <mx-table-cell>400</mx-table-cell>
           <mx-table-cell>40</mx-table-cell>
-          <mx-table-cell>
-            <mx-button btn-type="text" icon="icon icon-visibility">Preview</mx-button>
-            <mx-button btn-type="text" icon="icon icon-event">Schedule Report</mx-button>
-          </mx-table-cell>
+          <mx-table-cell></mx-table-cell>
         </mx-table-row>
       </div>
     </mx-table>
+    <div slot="footer-left">
+      <a href="https://stellar.sso.listtrac.com/Account/SingleSignOn">
+        <img id="logo" src="/assets/list_trac/logo.png" width="105" height="48" alt="ListTrac" />
+      </a>
+    </div>
   </mx-modal>
 </div>
 
@@ -168,7 +157,7 @@ const sendCloseMessage = () => {
   );
 }
 const modal = root.querySelector("mx-modal");
-setTimeout(() => modal.isOpen = true, 200);
+setTimeout(() => modal.isOpen = true, 400);
 modal.addEventListener("mxClose", sendCloseMessage);
 /* We have to recreate the close button since we are overriding the default content of the 
 /* header-right slot. */
@@ -183,11 +172,65 @@ document.addEventListener("keydown", (e) => {
 const table = root.querySelector("mx-table");
 table.columns = [
   { heading: "Listing" },
-  { heading: "Status" },
-  { heading: "Views" },
-  { heading: "Leads" },
-  { isActionColumn: true, align: 'right', cellClass: 'sm:p-0' },
+  { heading: "Views", align: "right" },
+  { heading: "Leads", align: "right" },
+  { isActionColumn: true } // Design has a blank column here
 ];
 
+</script>
+
+<% elsif current_page?(component_named_settings_path('list_trac')) %>
+
+<%# Settings %>
+<div class="list_trac w-screen h-screen">
+  <mx-modal close-on-escape="false">
+    <div slot="header-left"><%= @heading %> | Settings</div>
+    <div slot="header-right"></div>
+    <div class="settings-inner">
+      <mx-select label="Default display" class="mb-24">
+        <option>Latest activity</option>
+        <option>Views: most to least</option>
+        <option>Views: least to most</option>
+        <option>Leads: most to least</option>
+        <option>Leads: least to most</option>
+      </mx-select>
+      <mx-select label="Time frame">
+        <option>Last 14 days</option>
+        <option>Last 30 days</option>
+        <option>Last 90 days</option>
+        <option>Last 180 days</option>
+        <option>Last year</option>
+        <option>All-time</option>
+      </mx-select>
+    </div>
+    <div slot="footer-left">
+      <a href="https://stellar.sso.listtrac.com/Account/SingleSignOn">
+        <img id="logo" src="/assets/list_trac/logo.png" width="105" height="48" alt="ListTrac" />
+      </a>
+    </div>
+    <div slot="footer-right">
+      <mx-button btn-type="outlined">Cancel</mx-button> 
+      <mx-button>Save</mx-button>
+    </div>
+  </mx-modal>
+</div>
+
+<%# Settings Script %>
+<script type="module">
+const root = document.querySelector('.list_trac');
+const sendCloseMessage = () => {
+  window.parent.postMessage(
+    { type: "CLOSE_EXPANDED", payload: {} },
+    "*"
+  );
+}
+const modal = root.querySelector("mx-modal");
+setTimeout(() => modal.isOpen = true, 400);
+modal.addEventListener("mxClose", sendCloseMessage);
+
+/* The close-on-escape behavior provided by mx-modal does not work in an iframe. */
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") sendCloseMessage();
+});
 </script>
 <% end %>

--- a/app/components/list_trac/list_trac_component.rb
+++ b/app/components/list_trac/list_trac_component.rb
@@ -10,6 +10,7 @@ class ListTrac::ListTracComponent < ViewComponent::Base
     @library_mode ||= params[:library_mode]
     @token = token # TODO: Remove once API is working for us
     @listings = @library_mode ? demo_listings : agent_listings
+    @heading = "Online Activity"
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
   get "component/:name/:session_id" => "component#name", :as => :component_named_default
   get "component/:name/expanded/:session_id" => "component#name", :as => :component_named_expanded
+  get "component/:name/settings/:session_id" => "component#name", :as => :component_named_settings
 
   root "welcome#index"
 end


### PR DESCRIPTION
## Description

- Added a new settings route for components.
- Built the settings modal for ListTrac.  I didn't bother with the Hurdlr settings modal just yet because I'm skeptical that we'll get Hurdlr to update their API for the settings in our design.
- Updated the expanded modal for ListTrac to match the latest design.
- Made the widget headings use an instance variable since those will be configurable in the widget admin.
- Also fixed the intermittent issues with the ListTrac expanded modal not opening.  Instead of waiting an arbitrary amount of time for the modal element to be ready to open, I've added a mutation observer that waits to open the modal until the wrapper element's child tree changes (presumably when the modal elements settle into place).  I also applied this fix to the new settings modal.

![image](https://user-images.githubusercontent.com/3342530/212123682-38a83814-4974-40ca-a0fd-1fb05aaad086.png)

![image](https://user-images.githubusercontent.com/3342530/212127677-6b529238-bab8-4627-a6a0-2f36561f925b.png)

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-44
https://www.figma.com/file/S5TevaRcPuPa6wJNZePI5K/Widgets?node-id=2224%3A201588&t=6z9fVrkBKM6kRwal-0
