### PR TITLE
Implement adding, removing, and reordering user widgets

### DIFF
--- a/app/assets/stylesheets/widget_panel/style.css
+++ b/app/assets/stylesheets/widget_panel/style.css
@@ -32,13 +32,16 @@
 .keyboard-drag-button {
   outline-offset: 0.25rem;
 }
-.add-button {
+.add-button,
+.remove-button {
   --mds-text-btn-text-disabled: var(--secondary);
 }
 .remove-button,
 .added-button {
-  --mds-text-btn-text-disabled: currentColor;
   --mds-text-btn-text: currentColor;
+}
+.added-button {
+  --mds-text-btn-text-disabled: currentColor;
 }
 .remove-button:active ~ .added-button,
 .remove-button:focus-within ~ .added-button,

--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -34,7 +34,6 @@
           <span class="icon icon-dots-three-vertical"></span>
         </button>
         <mx-menu>
-          <mx-menu-item>Modify settings</mx-menu-item>
           <mx-menu-item>Remove widget</mx-menu-item>
         </mx-menu>
       <% end %>
@@ -118,13 +117,7 @@ if (menuItems.length) {
 
   menuItems[0].addEventListener("click", () => {
     window.parent.postMessage(
-      { type: "MODIFY_SETTINGS", payload: {} },
-      "*"
-    );
-  });
-  menuItems[1].addEventListener("click", () => {
-    window.parent.postMessage(
-      { type: "REMOVE", payload: {} },
+      { type: "REMOVE", payload: { component: 'hurdlr' } },
       "*"
     );
   });

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -227,7 +227,7 @@ if (menuItems.length) {
   });
   menuItems[1].addEventListener("click", () => {
     window.parent.postMessage(
-      { type: "REMOVE", payload: {} },
+      { type: "REMOVE", payload: { component: 'list_trac' } },
       "*"
     );
   });

--- a/app/components/widget_panel/widget_panel_component.html.erb
+++ b/app/components/widget_panel/widget_panel_component.html.erb
@@ -7,38 +7,40 @@
     <p id="widgets-heading" role="heading" aria-level="1" class="my-0 subtitle2">My Widgets</p>
     <mx-button btn-type="text" icon="icon icon-plus-circle">Add</mx-button>
   </header>
-  <% if @user_widget_components.any? %>
+  <% if @user_widgets.any? %>
     <p id="reorder-help" class="sr-only">
       Activate the reorder button and use the arrow keys to reorder the list. Press Escape or Tab to cancel the reordering.
     </p>
     <ol class="widget-grid" aria-labelledby="widgets-heading">
-      <% @user_widget_components.each do |widget| %>
-        <li data-widget="<%= widget %>"><%= render Object.const_get("#{widget.camelize}::#{widget.camelize}Component").new %></li>
+      <% @user_widgets.each do |user_widget| %>
+        <li data-widget-id="<%= user_widget.widget.id %>" data-widget-component="<%= user_widget.widget.component %>" data-widget-name="<%= user_widget.widget.name %>">
+          <%= render Object.const_get("#{user_widget.widget.component.camelize}::#{user_widget.widget.component.camelize}Component").new %>
+        </li>
       <% end %>
     </ol>
-  <% else %>
-    <div class="text-center">
-      <div class="text-h5 my-0 mt-24 mb-8">
-        No widgets to show yet
-      </div>
-      <div class="mb-16">
-        Widgets offer a convenient pulse check of your real estate ecosystem by surfacing essential activity and insights right from your dashboard. Select “Add” to get started.
-      </div>
-      <%= image_tag "empty-state.svg", alt: "", role: "presentation", class: "mx-auto", style: "width: 200px;" %>
-    </div>
   <% end %>
+  <div class="empty-state text-center <%= @user_widgets.any? ? "hidden" : "" %>">
+    <div class="text-h5 my-0 mt-24 mb-8">
+      No widgets to show yet
+    </div>
+    <div class="mb-16">
+      Widgets offer a convenient pulse check of your real estate ecosystem by surfacing essential activity and insights right from your dashboard. Select “Add” to get started.
+    </div>
+    <%= image_tag "empty-state.svg", alt: "", role: "presentation", class: "mx-auto", style: "width: 200px;" %>
+  </div>
 </section>
 
 <%# Inline Widget Script (My Widgets) %>
 <script type="module">
 const WIDGET_LIBRARY = 'widget_library';
+const SESSION_ID = '<%= params[:session_id] %>';
 const root = document.querySelector('.widget_panel');
 
 // Notify parent window of height changes
 const resizeObserver = new ResizeObserver(entries => {
   const height = entries[0].contentRect.height;
   window.parent.postMessage(
-    { type: 'RESIZE', payload: { id: 'widget_panel', height } },
+    { type: 'RESIZE', payload: { component: 'widget_panel', height } },
     '*'
   );
 });
@@ -52,16 +54,32 @@ if (addButton) {
   });
 }
 
+window.addEventListener('message', e => {
+  const { type, payload } = e.data;
+  if (type === 'REMOVE') removeWidget(payload.component);
+});
+
+function removeWidget(component) {
+  const widget = root.querySelector(`[data-widget-component="${component}"]`);
+  destroyUserWidget(widget.dataset.widgetId);
+  widget.remove();
+  if (!root.querySelector('li')) {
+    root.querySelector('.empty-state').classList.remove('hidden');
+  } else {
+    resetWidgetOrderAttributes();
+  }
+}
+
 // Drag sorting
 
 const KEYBOARD_DRAG_CLASSES = ['transform', '-translate-y-10'];
 const MOUSE_DRAG_CLASSES = ['z-50', 'pointer-events-none'];
-const dragHandleHtml = widget => `
+const dragHandleHtml = name => `
   <div class="touch-drag-handle mr-10">
     <button
       class="keyboard-drag-button flex pointer-events-none"
       aria-describedby="reorder-help"
-      aria-label="Reorder ${widget}"
+      aria-label="Reorder ${name}"
     >
       <span class="icon icon-drag"></span>
     </button>
@@ -76,7 +94,7 @@ widgets.forEach((widget, i) => {
   const header = widget.querySelector('header');
   header.insertAdjacentHTML(
     'afterbegin',
-    dragHandleHtml(widget.dataset.widget)
+    dragHandleHtml(widget.dataset.widgetName)
   );
   header.classList.add('cursor-move');
   widget.addEventListener('mousedown', onPointerDown);
@@ -225,6 +243,7 @@ function reorderWidgetElements() {
       (a, b) => getOrder(a) - getOrder(b)
     );
     orderedWidgets.forEach(widget => draggedWidget.parentElement.appendChild(widget));
+    updateUserWidget();
     overWidget = null;
   }
   resetWidgetOrderAttributes();
@@ -252,6 +271,27 @@ function getPointer(e) {
     return e;
   }
 }
+
+function updateUserWidget() {
+  if (!draggedWidget) return;
+  const widgetId = draggedWidget.dataset.widgetId;
+  _fetch(`/api/user_widgets/${widgetId}?session_id=${SESSION_ID}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ row_order_position: getOrder(draggedWidget) })
+  });
+}
+function destroyUserWidget(widgetId) {
+  return _fetch(`/api/user_widgets/${widgetId}?session_id=${SESSION_ID}`, {
+    method: 'DELETE',
+  })
+}
+async function _fetch(url, options) {
+  options = { ...options, headers: { 'Content-Type': 'application/json' } }
+  const response = await fetch(url, options)
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+}
 </script>
 
 <% else %>
@@ -261,16 +301,17 @@ function getPointer(e) {
     <div slot="header-left">Library</div>
     <div class="widget-library-grid">
       <% @active_widgets.each do |widget| %>
-        <div data-widget="<%= widget %>" class="px-16 pt-16 pb-24 bg-white rounded-lg">
+        <% added = @user_widgets.find_by(widget: widget).present? %>
+        <div data-widget-id="<%= widget.id %>" class="px-16 pt-16 pb-24 bg-white rounded-lg">
           <div class="px-8 mb-20">
-            <mx-button btn-type="text" icon="icon icon-plus-circle" class="add-button <%= @user_widget_components.include?(widget.component) ? "hidden" : "" %>">
+            <mx-button btn-type="text" icon="icon icon-plus-circle" class="add-button <%= added ? "hidden" : "" %>">
               <span class="button-text">Add widget</span>
             </mx-button>
-            <div class="remove-button-wrapper relative <%= @user_widget_components.include?(widget.component) ? "" : "hidden" %>">
+            <div class="remove-button-wrapper relative <%= added ? "" : "hidden" %>">
               <!-- It was cleaner to do this with two buttons and CSS instead of JavaScript. -->
               <!-- Remove button that is hovered/focused/active.  -->
               <mx-button btn-type="text" icon="icon icon-minus-circle" class="remove-button absolute left-0 opacity-0 hover:opacity-100 focus-within:opacity-100">
-                Remove from Dashboard
+                <span class="button-text">Remove from Dashboard</span>
               </mx-button>
               <!-- Not hovered/focused/active -->
               <mx-button btn-type="text" icon="icon icon-checkbox-circle" class="added-button pointer-events-none" disabled>
@@ -295,6 +336,7 @@ function getPointer(e) {
 
 <%# Expanded Widget Script (Widget Library) %>
 <script type="module">
+const SESSION_ID = '<%= params[:session_id] %>';
 const root = document.querySelector('.widget_panel');
 const sendCloseMessage = () => {
   window.parent.postMessage(
@@ -312,36 +354,77 @@ document.addEventListener("keydown", (e) => {
 
 const addButtons = root.querySelectorAll(".add-button");
 addButtons.forEach((button) => {
-  button.addEventListener("click", (e) => {
-    const widget = e.target.closest('[data-widget]').dataset.widget;
-    // TODO: Add widget to user's dashboard
+  button.addEventListener("click", async (e) => {
+    const widgetId = e.target.closest('[data-widget-id]').dataset.widgetId;
     // Show "Adding widget" button
-    const mxButton = e.target.closest('mx-button');
-    mxButton.icon = 'icon icon-arrows-clockwise';
-    mxButton.querySelector('.button-text').innerText = 'Adding widget'
-    mxButton.disabled = true;
-    setTimeout(() => {
+    const addButton = e.target.closest('mx-button');
+    const removeButtonWrapper = addButton.parentElement.querySelector('.remove-button-wrapper');
+    addButton.icon = 'icon icon-arrows-clockwise';
+    addButton.querySelector('.button-text').innerText = 'Adding widget'
+    addButton.disabled = true;
+    try {
+      await createUserWidget(widgetId);
       // Replace add button with remove button
-      mxButton.classList.add('hidden')
-      mxButton.icon = 'icon icon-plus-circle';
-      mxButton.querySelector('.button-text').innerText = 'Add widget'
-      mxButton.disabled = false;
-      const removeButtonWrapper = mxButton.parentElement.querySelector('.remove-button-wrapper');
+      addButton.classList.add('hidden')
       removeButtonWrapper.classList.remove('hidden');
-    }, 500)
+    } catch(err) {
+      console.error(err);
+    } finally {
+      addButton.icon = 'icon icon-plus-circle';
+      addButton.querySelector('.button-text').innerText = 'Add widget'
+      addButton.disabled = false;
+    }
   });
 });
 const removeButtons = root.querySelectorAll(".remove-button");
 removeButtons.forEach((button) => {
-  button.addEventListener("click", (e) => {
-    const widget = e.target.closest('[data-widget]').dataset.widget;
-    // TODO: Remove widget
+  button.addEventListener("click", async (e) => {
+    const widgetId = e.target.closest('[data-widget-id]').dataset.widgetId;
+    const removeButton = e.target.closest('mx-button');
     const removeButtonWrapper = e.target.closest('.remove-button-wrapper');
-    // Replace remove button with add button
-    removeButtonWrapper.classList.add('hidden');
+    const addedButton = removeButtonWrapper.querySelector('.added-button');
     const addButton = removeButtonWrapper.parentElement.querySelector('.add-button');
-    addButton.classList.remove('hidden');
+    removeButton.icon = 'icon icon-arrows-clockwise';
+    removeButton.classList.replace('opacity-0', 'opacity-100');
+    addedButton.classList.add('opacity-0');
+    removeButton.querySelector('.button-text').innerText = 'Removing widget'
+    removeButton.disabled = true;
+    try {
+      await destroyUserWidget(widgetId);
+      // Replace remove button with add button
+      addButton.classList.remove('hidden');
+      removeButtonWrapper.classList.add('hidden');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      removeButton.classList.replace('opacity-100', 'opacity-0');
+      addedButton.classList.remove('opacity-0');
+      removeButton.icon = 'icon icon-minus-circle';
+      removeButton.querySelector('.button-text').innerText = 'Remove from Dashboard'
+      removeButton.disabled = false;
+    }
   });
 });
+
+function createUserWidget(widgetId) {
+  return _fetch(`/api/user_widgets?session_id=${SESSION_ID}`, {
+    method: 'POST',
+    body: JSON.stringify({ widget_id: widgetId, row_order_position: 'last' })
+  })
+}
+function destroyUserWidget(widgetId) {
+  return _fetch(`/api/user_widgets/${widgetId}?session_id=${SESSION_ID}`, {
+    method: 'DELETE',
+  })
+}
+async function _fetch(url, options) {
+  options = { ...options, headers: { 'Content-Type': 'application/json' } }
+  const response = await fetch(url, options)
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  } else {
+    window.parent.postMessage({ type: 'REFRESH', payload: { component: 'widget_panel' } }, "*");
+  }
+}
 </script>
 <% end %>

--- a/app/components/widget_panel/widget_panel_component.rb
+++ b/app/components/widget_panel/widget_panel_component.rb
@@ -4,10 +4,9 @@ class WidgetPanel::WidgetPanelComponent < ViewComponent::Base
   def before_render
     @active_widgets = Widget.activated_widgets.where(internal: false)
     @user_uuid = session[:current_user][:uuid]
-    @user_widget_components = UserWidget.where(user_uuid: session[:current_user][:uuid])
+    @user_widgets = UserWidget.where(user_uuid: session[:current_user][:uuid])
       .where(widgets: Widget.activated_widgets)
       .joins(:widget)
       .rank(:row_order)
-      .pluck(:component)
   end
 end

--- a/app/controllers/api/user_widgets_controller.rb
+++ b/app/controllers/api/user_widgets_controller.rb
@@ -1,0 +1,41 @@
+class Api::UserWidgetsController < ApplicationController
+  before_action :set_user_widget, only: [:update, :destroy]
+  skip_before_action :verify_authenticity_token
+
+  # POST /api/user_widgets
+  def create
+    @user_widget = UserWidget.new(user_widget_params)
+    @user_widget.user_uuid = session[:current_user][:uuid]
+
+    if @user_widget.save
+      render json: @user_widget, status: :created
+    else
+      render json: @user_widget.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /api/user_widgets/1
+  def update
+    if @user_widget.update(user_widget_params)
+      render json: @user_widget
+    else
+      render json: @user_widget.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /api/user_widgets/1
+  def destroy
+    @user_widget.destroy
+  end
+
+  private
+
+  def set_user_widget
+    user_uuid = session[:current_user][:uuid]
+    @user_widget = UserWidget.find_by(widget_id: params[:id], user_uuid: user_uuid)
+  end
+
+  def user_widget_params
+    params.permit(:widget_id, :row_order_position)
+  end
+end

--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -3,7 +3,7 @@ class Api::WidgetsController < ApplicationController
 
   # GET /api/widgets
   def index
-    @widgets = Widget.activated_widgets.where(internal: false)
+    @widgets = Widget.where(internal: false)
     render json: @widgets
   end
 

--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -1,0 +1,31 @@
+class Api::WidgetsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  # GET /api/widgets
+  def index
+    @widgets = Widget.activated_widgets.where(internal: false)
+    render json: @widgets
+  end
+
+  # GET /api/widgets/1
+  def show
+    @widget = Widget.find(params[:id])
+    render json: @widget
+  end
+
+  # PATCH/PUT /api/widgets/1
+  def update
+    @widget = Widget.find(params[:id])
+    if @widget.update(widget_params)
+      render json: @widget
+    else
+      render json: @widget.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def widget_params
+    params.require(:widget).permit(:name, :description, :status, :activation_date)
+  end
+end

--- a/app/helpers/api/user_widgets_helper.rb
+++ b/app/helpers/api/user_widgets_helper.rb
@@ -1,0 +1,2 @@
+module Api::UserWidgetsHelper
+end

--- a/app/helpers/api/widgets_helper.rb
+++ b/app/helpers/api/widgets_helper.rb
@@ -1,0 +1,2 @@
+module Api::WidgetsHelper
+end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -3,9 +3,23 @@ class Widget < ApplicationRecord
 
   scope :activated_widgets, -> {
     where(status: Widget.statuses[:ready], activation_date: ..Time.zone.now)
+      .or(where(status: Widget.statuses[:ready], activation_date: nil))
   }
 
   validates :name, presence: true
+
+  def as_json(options = {})
+    options[:methods] = [:activated, :logo_url]
+    super
+  end
+
+  def activated
+    status == Widget.statuses[:ready] && (activation_date.blank? || activation_date <= Time.zone.now)
+  end
+
+  def logo_url
+    "/assets/#{component}/logo.png"
+  end
 
   def restore!
     self.status = Widget.statuses[:draft]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,10 @@ Rails.application.routes.draw do
   get "component/:name/expanded/:session_id" => "component#name", :as => :component_named_expanded
   get "component/:name/settings/:session_id" => "component#name", :as => :component_named_settings
 
+  namespace :api do
+    resources :widgets
+    resources :user_widgets
+  end
+
   root "welcome#index"
 end

--- a/test/controllers/api/user_widgets_controller_test.rb
+++ b/test/controllers/api/user_widgets_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::UserWidgetsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/api/widgets_controller_test.rb
+++ b/test/controllers/api/widgets_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::WidgetsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Description

This implements:
- adding and removing widgets from a user's dashboard via the library modal,
- removing a widget via the widget action menu,
- reordering widgets,
- and the API endpoints for both UserWidgets and Widgets.

I will probably circle back at some point to see about adding loading spinners or _something_ when "My Widgets" is refreshing after making changes in the library modal.

I will do a PR in nucleus for some changes that go along with this (https://github.com/moxiworks/nucleus/pull/701).


## JIRA Link
https://moxiworks.atlassian.net/browse/OT-44
https://moxiworks.atlassian.net/browse/OT-45

## Validation Steps
Verify that widgets can be added/removed from the library.  Verify they can be removed from the "My Widgets" panel as well.  When all widgets are removed from "My Widgets", the empty state should be shown.

![Recording 2023-01-27 at 10 54 35](https://user-images.githubusercontent.com/3342530/215130012-03c1940a-75ab-4960-8927-ca0b3d20b7b7.gif)

![Recording 2023-01-27 at 10 40 21](https://user-images.githubusercontent.com/3342530/215128425-bb1d850c-5094-4500-88e8-3a48a63647c6.gif)

