### PR TITLE
Set cache path to entire url (with query params)

### DIFF
--- a/app/controllers/component_controller.rb
+++ b/app/controllers/component_controller.rb
@@ -1,7 +1,7 @@
 class ComponentController < ApplicationController
   include Cacheable
 
-  caches_action :name, expires_in: default_cache_time
+  caches_action :name, expires_in: default_cache_time, cache_path: proc { |c| c.request.url }
 
   def name
     # Looks for namespaced component first.


### PR DESCRIPTION
## Description

The action caching was not taking query string parameters into account, which we are using heavily, in addition to route params.  The updates the `cache_path` to the entire URL.