### PR TITLE
Switch to single token in vendor api data

### DIFF
--- a/app/components/hurdlr/hurdlr_component.rb
+++ b/app/components/hurdlr/hurdlr_component.rb
@@ -17,7 +17,7 @@ class Hurdlr::HurdlrComponent < ViewComponent::Base
 
   def api_post(endpoint, payload)
     base_url = Rails.env.development? ? "https://sandbox.hurdlr.com/rest/v1/enterprise" : "https://app.hurdlr.com/rest/v1/enterprise"
-    token = VendorApiAccess["hurdlr"][Rails.env.development? ? "sandbox_token" : "production_token"]
+    token = VendorApiAccess["hurdlr"]["token"]
     begin
       response = RestClient.post("#{base_url}/#{endpoint}", payload.to_json, {Authorization: "Bearer #{token}"})
       data = JSON.parse(response, symbolize_names: true)

--- a/config/vendor_api_data.example.yml
+++ b/config/vendor_api_data.example.yml
@@ -1,6 +1,5 @@
 hurdlr:
-  sandbox_token: 'XX'
-  production_token: 'XX'
+  token: 'XX'
   test_user_id: ''
 
 list_trac:


### PR DESCRIPTION
## Description

Per advice from @aroop, switching to a single `token` instead of `production_token` and `sandbox_token` since we can just swap out different `vendor_api_data` depending on the environment.
