### PR TITLE
Handle missing view component files

### DIFF
--- a/app/components/widget_panel/widget_panel_component.html.erb
+++ b/app/components/widget_panel/widget_panel_component.html.erb
@@ -14,7 +14,7 @@
     <ol class="widget-grid overflow-hidden pb-96" aria-labelledby="widgets-heading">
       <% @user_widgets.each do |user_widget| %>
         <li data-widget-id="<%= user_widget.widget.id %>" data-widget-component="<%= user_widget.widget.component %>" data-widget-name="<%= user_widget.widget.name %>">
-          <%= render Object.const_get("#{user_widget.widget.component.camelize}::#{user_widget.widget.component.camelize}Component").new %>
+          <%= render user_widget.widget.view_component.new %>
         </li>
       <% end %>
     </ol>
@@ -336,7 +336,7 @@ async function _fetch(url, options) {
               </mx-button>
             </div>
           </div>
-          <%= render Object.const_get("#{widget.component.camelize}::#{widget.component.camelize}Component").new(library_mode: true) %>
+          <%= render widget.view_component.new(library_mode: true) %>
           <div class="px-8 mt-20">
             <p role="heading" aria-level="3" class="overline2 my-0 mb-8">
               Description

--- a/app/components/widget_panel/widget_panel_component.rb
+++ b/app/components/widget_panel/widget_panel_component.rb
@@ -4,6 +4,8 @@ class WidgetPanel::WidgetPanelComponent < ViewComponent::Base
   def before_render
     permitted_components = params[:components].split(",").map(&:to_sym)
     @active_widgets = Widget.activated_widgets.where(internal: false, component: permitted_components)
+    # Ensure that a view component exists for each widget (in case a component is removed or is on another branch)
+    @active_widgets = @active_widgets.filter { |w| w.view_component.present? }
     @user_uuid = session[:current_user][:uuid]
     @user_widgets = UserWidget.where(user_uuid: session[:current_user][:uuid])
       .where(widgets: @active_widgets)

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -21,6 +21,12 @@ class Widget < ApplicationRecord
     status == Widget.statuses[:ready] && (activation_date.blank? || activation_date <= Time.zone.now)
   end
 
+  def view_component
+    Object.const_get("#{component.camelize}::#{component.camelize}Component")
+  rescue NameError
+    nil
+  end
+
   def logo_url
     return unless logo.attached?
     Rails.application.routes.url_helpers.rails_representation_url(logo, only_path: true)


### PR DESCRIPTION
## Description

We use a `Object.const_get()` call to find the view component class for a widget.  Previously, this was in the view, which meant that if you added the `tips` widget to a user's widget panel, for example, and then switched to a branch that did not have that component, you would get an "Uninitialized constant" error.

This PR:
- Moves the `Object.const_get()` call to a `Widget.view_component` instance method that falls back to `nil`
- Filters the widget panel's `@active_widgets` to only show widgets that have a `view_component` to render