### PR TITLE
Hurdlr fixes

### DIFF
--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -76,10 +76,10 @@
 <script type="module">
 const root = document.querySelector('.hurdlr');
 const rows = [
-  { label: 'Income', key: 'revenue', value: <%= @data[:revenue] %> },
-  { label: 'Expenses', key: 'expenses', value: <%= @data[:expenses] %> },
-  { label: 'Taxes', key: 'overallTaxAmount', value: <%= @data[:overallTaxAmount] %> },
-  { label: 'Profit after tax', key: 'afterTaxIncome', value: <%= @data[:afterTaxIncome] %> },
+  { label: 'Income', key: 'revenue', value: <%= @data[:revenue] || 0 %> },
+  { label: 'Expenses', key: 'expenses', value: <%= @data[:expenses] || 0 %> },
+  { label: 'Taxes', key: 'overallTaxAmount', value: <%= @data[:overallTaxAmount] || 0 %> },
+  { label: 'Profit after tax', key: 'afterTaxIncome', value: <%= @data[:afterTaxIncome] || 0 %> },
 ];
 const formatUSD = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -91,7 +91,7 @@ const tbody = root.querySelector('tbody');
 // Generate the table rows
 rows.forEach(row => {
   const tr = document.createElement('tr');
-  let percent = row.value / <%= @data[:revenue] %> * 100;
+  let percent = row.value / <%= @data[:revenue] || 0 %> * 100;
   if (isNaN(percent)) percent = 0;
   tr.innerHTML = `
     <td aria-labelledby="metric-heading" id="${row.key}-label">

--- a/app/components/hurdlr/hurdlr_component.rb
+++ b/app/components/hurdlr/hurdlr_component.rb
@@ -12,11 +12,12 @@ class Hurdlr::HurdlrComponent < ViewComponent::Base
   end
 
   def user_vitals
-    api_post("userVitals", {userId: VendorApiAccess["hurdlr"]["test_user_id"]})
+    api_post("userVitals", {userId: session[:current_user][:mls_number]})
+    # api_post("userVitals", {userId: VendorApiAccess["hurdlr"]["test_user_id"]})
   end
 
   def api_post(endpoint, payload)
-    base_url = Rails.env.development? ? "https://sandbox.hurdlr.com/rest/v1/enterprise" : "https://app.hurdlr.com/rest/v1/enterprise"
+    base_url = (Rails.env.production? || Rails.env.uat?) ? "https://app.hurdlr.com/rest/v1/enterprise" : "https://sandbox.hurdlr.com/rest/v1/enterprise"
     token = VendorApiAccess["hurdlr"]["token"]
     begin
       response = RestClient.post("#{base_url}/#{endpoint}", payload.to_json, {Authorization: "Bearer #{token}"})


### PR DESCRIPTION
## Description

- Provided fallback `@data` values inside the inline JavaScript.  Otherwise, if the API responds with an error and no good data, we would end up with lines like `{ label: 'Income', key: 'revenue', value:  }` (resulting in syntax errors in the browser console).
- Updated the hurdlr `user_vitals` API call to use the MLS ID from the user session instead of our test ID.  We may still use the test ID for some environments, depending on how hurdlr responds to Drew's latest email regarding test data.
- Changed the logic for the hurdlr API URL so that we use their production URL for both production and UAT; otherwise, we use their sandbox URL.  Ajay already configured the token this same way in the AWS Secrets Manager.
