### PR TITLE
OT-121 && OT-122 - Remove action caching from components; Prevent duplicate user widgets

### DIFF
--- a/app/controllers/api/user_widgets_controller.rb
+++ b/app/controllers/api/user_widgets_controller.rb
@@ -1,9 +1,11 @@
 class Api::UserWidgetsController < ApplicationController
-  before_action :set_user_widget, only: [:update, :destroy]
+  before_action :set_user_widget, only: [:create, :update, :destroy]
   skip_before_action :verify_authenticity_token
 
   # POST /api/user_widgets
   def create
+    return render json: @user_widget, status: :ok if @user_widget.present? # Prevent duplicates
+
     @user_widget = UserWidget.new(user_widget_params)
     @user_widget.user_uuid = session[:current_user][:uuid]
 
@@ -32,7 +34,7 @@ class Api::UserWidgetsController < ApplicationController
 
   def set_user_widget
     user_uuid = session[:current_user][:uuid]
-    @user_widget = UserWidget.find_by(widget_id: params[:id], user_uuid: user_uuid)
+    @user_widget = UserWidget.find_by(widget_id: params[:id] || params[:widget_id], user_uuid: user_uuid)
   end
 
   def user_widget_params

--- a/app/controllers/component_controller.rb
+++ b/app/controllers/component_controller.rb
@@ -1,8 +1,4 @@
 class ComponentController < ApplicationController
-  include Cacheable
-
-  caches_action :name, expires_in: default_cache_time, cache_path: proc { |c| c.request.url }
-
   def name
     # Looks for namespaced component first.
     obj = begin


### PR DESCRIPTION
## Description

This removes action caching from the component controller.  There are just too many things that can change.

I also made it so that it should be impossible to create multiple `UserWidget` records for the same `widget_id` and `user_uuid`.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-121
https://moxiworks.atlassian.net/browse/OT-122

## Validation Steps
Verify that adding/removing widgets via the Widget Library takes effect immediately.
Verify that (de)activating widgets takes effect immediately (or at least after reloading the page).
