### PR TITLE
OT-129 - Use Widget.logo_url

### DIFF
--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -51,7 +51,7 @@
     <% end %>
     <img
       id="logo"
-      src="<%= @widget.logo.attached? ? url_for(@widget.logo) : "" %>"
+      src="<%= @widget.logo.attached? ? @widget.logo_url : "" %>"
       class="<%= @widget.logo.attached? ? "" : "hidden" %>"
       width="64"
       height="30"

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -14,7 +14,7 @@
     <div slot="footer-left">
       <% if @widget.logo.attached? %>
         <a href="<%= @widget.logo_link_url %>" target="_blank">
-          <img id="logo" src="<%= url_for(@widget.logo) %>" width="105" height="48" alt="<%= @widget.partner %>" />
+          <img id="logo" src="<%= @widget.logo_url %>" width="105" height="48" alt="<%= @widget.partner %>" />
         </a>
       <% end %>
     </div>
@@ -149,7 +149,7 @@ table.columns = [
     <% end %>
     <img
       id="logo"
-      src="<%= @widget.logo.attached? ? url_for(@widget.logo) : "" %>"
+      src="<%= @widget.logo.attached? ? @widget.logo_url : "" %>"
       class="<%= @widget.logo.attached? ? "" : "hidden" %>"
       width="64"
       height="30"

--- a/app/components/tips/tips_component.html.erb
+++ b/app/components/tips/tips_component.html.erb
@@ -21,7 +21,7 @@
   >
     <img
       id="logo"
-      src="<%= @widget.logo.attached? ? url_for(@widget.logo) : "" %>"
+      src="<%= @widget.logo.attached? ? @widget.logo_url : "" %>"
       class="<%= @widget.logo.attached? ? "h-48" : "hidden" %>"
       alt="<%= @widget.partner %>"
     />


### PR DESCRIPTION
## Description

For some reason `url_for(@widget.logo)` sometimes returns an outdated URL.  I already had a `Widget.logo_url` method that uses `Rails.application.routes.url_helpers.rails_representation_url(logo, only_path: true)` instead, which seems to be more reliable.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-129
