### PR TITLE
Fix widget assets by using rails helpers

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,4 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link_tree ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js

--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -1,4 +1,4 @@
-<link rel="stylesheet" type="text/css" href="/assets/hurdlr/style.css">
+<%= stylesheet_link_tag "hurdlr/style" %>
 
 <div class="hurdlr inline-widget relative flex flex-col border bg-white text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -1,5 +1,5 @@
 <!-- Token: <%= @token %> -->
-<link rel="stylesheet" type="text/css" href="/assets/list_trac/style.css">
+<%= stylesheet_link_tag "list_trac/style" %>
 
 <% if current_page?(component_named_expanded_path('list_trac')) %>
 
@@ -97,7 +97,7 @@ table.columns = [
           <tr>
             <td colspan="3">
               <div class="flex flex-col items-center justify-center">
-                <img src="/assets/design-tools.svg" class="w-72 h-72 mb-8" alt="">
+                <%= image_tag "design-tools.svg", alt: "", class: "w-72 h-72 mb-8" %>
                 <p class="caption2 my-0 whitespace-normal text-center">
                   We know you're working hard. When you have listings, you'll see them here.
                 </p>

--- a/app/components/tips/tips_component.html.erb
+++ b/app/components/tips/tips_component.html.erb
@@ -8,7 +8,7 @@
   </header>
   <div class="flex flex-1 py-12 px-16 tip-bg" style="--tip-bg: var(--tip-bg-<%= @bg %>)">
     <div class="tip-container w-full flex-1 flex flex-col items-center justify-center p-12 rounded-xl <%= @library_mode ? "pointer-events-none" : "" %>">
-      <p class="text-4 my-0 mb-8 text-center">
+      <p class="text-4 my-0 mb-8 text-center" style="overflow-wrap: anywhere">
         <%= @tip %>
       </p>
       <% if @cta_label.present? %>

--- a/app/components/tips/tips_component.html.erb
+++ b/app/components/tips/tips_component.html.erb
@@ -1,4 +1,4 @@
-<link rel="stylesheet" type="text/css" href="/assets/tips/style.css">
+<%= stylesheet_link_tag "tips/style" %>
 
 <div class="tips inline-widget relative flex flex-col border bg-white text-primary shadow-3 rounded-lg overflow-hidden m-8">
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">

--- a/app/components/widget_panel/widget_panel_component.html.erb
+++ b/app/components/widget_panel/widget_panel_component.html.erb
@@ -1,4 +1,4 @@
-<link rel="stylesheet" type="text/css" href="/assets/widget_panel/style.css">
+<%= stylesheet_link_tag "widget_panel/style" %>
 
 <% unless current_page?(component_named_expanded_path) %>
 <%# Inline Widget (My Widgets) %>


### PR DESCRIPTION
## Description

This replaces some `<link>` and `<img>` tags with rails asset helpers in order to use the correct files from the assets pipeline.

I also slipped in a fix for this text wrapping issue that Alex found in testing.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/3342530/227614993-097afaf7-6bae-4066-a52e-76c2d6d70b89.png)
