### PR TITLE
OT-134 - Fix retrieving user_uuid from session_id

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,8 @@ class ApplicationController < ActionController::Base
       auth_response = Resource::Auth.poll(params[:session_id])
 
       unless auth_response.nil?
-        response = Base.profile_request("#{Rails.application.config.base_profile_service_url}/profile/#{params[:user_uuid]}")
+        user_uuid = JSON.parse(auth_response, symbolize_names: true)[:vals][:context_user_uuid]
+        response = Base.profile_request("#{Rails.application.config.base_profile_service_url}/profile/#{user_uuid}")
         user = response[:data][0]
         Session.set_user_on_session(user, session)
       end


### PR DESCRIPTION
## Description

This fixes the current user_uuid always being the same id.  😦 We originally were passing the user_uuid as a param, but we eventually switched to passing the session_id so we could also verify they were logged in.  JP forgot to update it to use the data from the auth service, and I somehow never caught it until now.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-134
