### PR TITLE
OT-138 - Add Widget.updated_by (and remove updated_by_uuid)

### DIFF
--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -41,6 +41,6 @@ class Api::WidgetsController < ApplicationController
   end
 
   def widget_params
-    params.require(:widget).permit(:name, :description, :status, :activation_date, :remove_logo)
+    params.require(:widget).permit(:name, :description, :status, :activation_date, :remove_logo, :updated_by)
   end
 end

--- a/db/migrate/20230328134804_rename_updated_by_uuid_column.rb
+++ b/db/migrate/20230328134804_rename_updated_by_uuid_column.rb
@@ -1,0 +1,5 @@
+class RenameUpdatedByUuidColumn < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :widgets, :updated_by_uuid, :updated_by
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_194448) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_28_134804) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -67,7 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_194448) do
     t.string "status"
     t.datetime "activation_date"
     t.boolean "internal"
-    t.string "updated_by_uuid"
+    t.string "updated_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
## Description

This updates the widget model to have an `updated_by` value instead of `updated_by_uuid`.  This is only used to show the name of the user that last updated the widget.  Since the widget-factory might eventually be integrated into other applications, just storing the name instead of some proprietary uuid feels more future-proof.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-138

## Validation Steps
As long as https://github.com/moxiworks/nucleus/pull/776 is also deployed, a name should appear under Last Updated on the widget admin form (after performing a save).
