### PR TITLE
Remove excess padding on smaller screens

### DIFF
--- a/app/components/widget_panel/widget_panel_component.html.erb
+++ b/app/components/widget_panel/widget_panel_component.html.erb
@@ -11,7 +11,7 @@
     <p id="reorder-help" class="sr-only">
       Activate the reorder button and use the arrow keys to reorder the list. Press Escape or Tab to cancel the reordering.
     </p>
-    <ol class="widget-grid overflow-hidden pb-96" aria-labelledby="widgets-heading">
+    <ol class="widget-grid overflow-hidden md:pb-96" aria-labelledby="widgets-heading">
       <% @user_widgets.each do |user_widget| %>
         <li data-widget-id="<%= user_widget.widget.id %>" data-widget-component="<%= user_widget.widget.component %>" data-widget-name="<%= user_widget.widget.name %>">
           <%= render user_widget.widget.view_component.new %>


### PR DESCRIPTION
## Description

This goes along with https://github.com/moxiworks/nucleus/pull/785 to make the widget dashboard layout better match the design.

This bottom padding was previously added to give more wiggle room when dragging widgets, but it really should only be shown on larger screens.