### PR TITLE
OT-148 - API Controller Tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ group :test do
 end
 
 gem 'knapsack', group: [:development, :test]
+
+gem "webmock", "~> 3.18"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     dalli (3.2.3)
     debug (1.6.3)
@@ -163,6 +165,7 @@ GEM
     erubi (1.11.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     hashie (1.2.0)
     http-accept (1.7.0)
     http-cookie (1.0.5)
@@ -339,6 +342,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -384,6 +391,7 @@ DEPENDENCIES
   view_component
   web-console
   webdrivers
+  webmock (~> 3.18)
   wms_resource!
   wms_svc_consumer (~> 1.0.17)!
 

--- a/test/controllers/api/jwt_controller_test.rb
+++ b/test/controllers/api/jwt_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Api::JwtControllerTest < ActionController::TestCase
+  test "should create a JWT token with valid credentials" do
+    stub_request(:post, service_url("1234")).to_return(status: 200)
+    post :index, params: {uuid: "1234", password: Base64.encode64("password")}
+    assert_response :success
+    response_body = JSON.parse(@response.body)
+    assert_not_nil response_body["token"]
+    assert_not_nil response_body["exp"]
+  end
+
+  test "should return an error message if the profile service responds with 401" do
+    stub_request(:post, service_url("5678")).to_return(status: 401)
+    post :index, params: {uuid: "5678", password: Base64.encode64("wrong_password")}
+    assert_response :unauthorized
+    assert_equal "401 Unauthorized", JSON.parse(@response.body)["message"]
+  end
+
+  def service_url(uuid)
+    "#{Rails.application.config.base_profile_v2_service_url}/#{uuid}/validate_token"
+  end
+end

--- a/test/controllers/api/user_widgets_controller_test.rb
+++ b/test/controllers/api/user_widgets_controller_test.rb
@@ -1,7 +1,45 @@
 require "test_helper"
 
 class Api::UserWidgetsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  include JwtHelper
+
+  def setup
+    @user_uuid = "1234"
+    @widget = widgets(:one)
+    @jwt = get_jwt
+  end
+
+  test "should create user widget" do
+    assert_difference('UserWidget.count') do
+      post api_user_widgets_path, params: { widget_id: @widget.id, row_order_position: 1 }, headers: { "Authorization": @jwt }
+    end
+    assert_response :created
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    assert_equal @widget.id, response_body[:widget_id]
+    assert_equal @user_uuid, response_body[:user_uuid]
+  end
+
+  test "should not create duplicate user widget" do
+    user_widget = UserWidget.create(widget_id: @widget.id, user_uuid: @user_uuid, row_order_position: 1)
+    assert_no_difference('UserWidget.count') do
+      post api_user_widgets_path, params: { widget_id: @widget.id, row_order_position: 2 }, headers: { "Authorization": @jwt }
+    end
+    assert_response :ok
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    assert_equal user_widget.id, response_body[:id]
+  end
+
+  test "should update user widget" do
+    user_widget = UserWidget.create(widget_id: @widget.id, user_uuid: @user_uuid, row_order_position: :last)
+    patch api_user_widget_path(@widget.id), params: { row_order_position: :first }, headers: { "Authorization": @jwt }
+    assert_response :success
+  end
+
+  test "should destroy user widget" do
+    user_widget = UserWidget.create(widget_id: @widget.id, user_uuid: @user_uuid, row_order_position: 1)
+    assert_difference('UserWidget.count', -1) do
+      delete api_user_widget_path(@widget.id), headers: { "Authorization": @jwt }
+    end
+    assert_response :no_content
+  end
 end

--- a/test/controllers/api/widgets_controller_test.rb
+++ b/test/controllers/api/widgets_controller_test.rb
@@ -1,7 +1,42 @@
 require "test_helper"
 
-class Api::WidgetsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+class Api::WidgetsControllerTest < ActionController::TestCase
+  test "should get widgets" do
+    get :index
+    assert_response :success
+    response_body = JSON.parse(response.body)
+    assert_equal 2, response_body.length
+  end
+
+  test "should get single widget" do
+    widget = widgets(:one)
+    get :show, params: { id: widget.id }
+    assert_response :success
+    response_body = JSON.parse(response.body)
+    assert_equal widget.id, response_body["id"]
+  end
+
+  test "should update widget" do
+    widget = widgets(:one)
+    new_properties = {
+      name: "New Widget Name",
+      description: "New Widget Description",
+      status: "ready",
+      activation_date: "2023-04-07T00:00:00.000Z",
+      updated_by: "John Doe",
+      logo_base64: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    }
+    put :update, params: {
+      id: widget.id,
+      widget: new_properties
+    }
+    assert_response :success
+    response_body = JSON.parse(response.body)
+    assert_equal new_properties[:name], response_body["name"]
+    assert_equal new_properties[:description], response_body["description"]
+    assert_equal new_properties[:status], response_body["status"]
+    assert_equal new_properties[:activation_date], response_body["activation_date"]
+    assert_equal new_properties[:updated_by], response_body["updated_by"]
+    assert_not_nil response_body["logo_url"]
+  end
 end

--- a/test/fixtures/widgets.yml
+++ b/test/fixtures/widgets.yml
@@ -6,7 +6,7 @@ one:
   name: MyString
   description: MyString
   logo_link_url: MyString
-  status: MyString
+  status: ready
   activation_date: 2023-01-23 09:04:27
   internal: false
   updated_by: MyString

--- a/test/models/widget_test.rb
+++ b/test/models/widget_test.rb
@@ -13,13 +13,14 @@ class WidgetTest < ActiveSupport::TestCase
   end
 
   test "activated_widgets should return activated widgets" do
+    activated_fixture_count = Widget.activated_widgets.count
     Widget.create(name: "Draft Widget", status: "draft")
     Widget.create(name: "Ready Widget 1", status: "ready", activation_date: Time.now - 1.hour)
     Widget.create(name: "Ready Widget 2", status: "ready", activation_date: Time.now + 1.hour)
     Widget.create(name: "Deactivated Widget", status: "deactivated")
     activated_widgets = Widget.activated_widgets
-    assert_equal 1, activated_widgets.count
-    assert_equal ["Ready Widget 1"], activated_widgets.map(&:name).sort
+    assert_equal 1, activated_widgets.count - activated_fixture_count
+    assert_includes activated_widgets.map(&:name), "Ready Widget 1"
   end
 
   test "activated should return true for activated widgets" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV["RAILS_ENV"] ||= "test"
+require "webmock/minitest"
 require_relative "../config/environment"
 require "rails/test_help"
 
@@ -12,7 +13,24 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+
+  setup do
+    WebMock.allow_net_connect!
+  end  
 end
 
 knapsack_adapter = Knapsack::Adapters::MinitestAdapter.bind
 knapsack_adapter.set_test_helper_path(__FILE__)
+
+module JwtHelper
+  def get_jwt
+    # Stub authentication request
+    stub_request(:post, "#{Rails.application.config.base_profile_v2_service_url}/1234/validate_token").to_return(status: 200)
+    # Stub future requests to get user profile
+    stub_request(:get, "#{Rails.application.config.base_profile_service_url}/profile/1234")
+      .with(query: hash_including({}))
+      .to_return(status: 200, body: {data: [{uuid: "1234", office: {}, company: {}, board: {}}]}.to_json)
+    post api_jwt_path, params: {uuid: "1234", password: Base64.encode64("password")}
+    JSON.parse(@response.body)["token"]
+  end
+end


### PR DESCRIPTION
## Description

This adds 27 new assertions across 9 new test runs for the API controllers.  The `user_widgets_controller` tests required stubbing some JWT requests (using WebMock) since that controller relies on the user's UUID in the session.

I also fixed one of the widget fixtures that had an invalid value for `status`, which then required updating one of the `widget` model tests.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-148
