### PR TITLE
OT-150 - Add components tests for @error_with_api

### DIFF
--- a/test/components/hurdlr/hurdlr_component_test.rb
+++ b/test/components/hurdlr/hurdlr_component_test.rb
@@ -47,8 +47,19 @@ class Hurdlr::HurdlrComponentTest < ViewComponent::TestCase
     instance_variable_set(:@error, "unknown error") do
       assert_includes(
         rendered.to_html,
-        "Oh no something happened!"
+        "working on fixing things"
       )
+    end
+  end
+
+  def test_component_renders_error_with_api
+    instance_variable_set(:@error, "unknown error") do
+      instance_variable_set(:@error_with_api, true) do
+        assert_includes(
+          rendered.to_html,
+          "trouble connecting to Hurdlr"
+        )
+      end
     end
   end
 

--- a/test/components/list_trac/list_trac_component_test.rb
+++ b/test/components/list_trac/list_trac_component_test.rb
@@ -66,7 +66,18 @@ class ListTrac::ListTracComponentTest < ViewComponent::TestCase
       instance_variable_set(:@error, "unknown error") do
         assert_includes(
           rendered.to_html,
-          "Oh no something happened!"
+          "working on fixing things"
+        )
+      end
+    end
+  end
+
+  def test_component_renders_error_with_api
+    instance_variable_set(:@error, "unknown error") do
+      instance_variable_set(:@error_with_api, true) do
+        assert_includes(
+          rendered.to_html,
+          "trouble connecting to ListTrac"
         )
       end
     end


### PR DESCRIPTION
Adding additional tests to the component test files for the hurdlr and list_trac components.  These tests verify that the error message in the UI is updated when `@error_with_api` is true.