### PR TITLE
OT-152 - Add sidekiq and EventLoggerJob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,5 @@ end
 gem 'knapsack', group: [:development, :test]
 
 gem "webmock", "~> 3.18"
+
+gem "sidekiq", "~> 7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    connection_pool (2.4.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -267,6 +268,8 @@ GEM
       activerecord (>= 4.2)
     recursive-open-struct (0.3.1)
     redis (4.8.0)
+    redis-client (0.14.1)
+      connection_pool
     regexp_parser (2.6.1)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -303,6 +306,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.0.8)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     smart_properties (1.17.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
@@ -383,6 +391,7 @@ DEPENDENCIES
   rest-client
   rubocop-rails
   selenium-webdriver
+  sidekiq (~> 7.0)
   sprockets-rails
   sqlite3 (~> 1.4)
   standard

--- a/apdev.yml
+++ b/apdev.yml
@@ -4,7 +4,7 @@ version: '3.5'
 x-widget-factory: &1
   image: widget-factory-dev:1.0.0
   build:
-    context: "${APDEV_WIDGET_FACTORY_DIR:?}"
+    context: '${APDEV_WIDGET_FACTORY_DIR:?}'
     dockerfile: ops/dev/Dockerfile
     args:
       RUBY_VERSION: 3.0.2
@@ -13,35 +13,35 @@ x-widget-factory: &1
       PG_VERSION: '14'
       NPM_VERSION: 8.19.2
   tmpfs:
-  - "/tmp"
-  - "/app/tmp/pids"
+    - '/tmp'
+    - '/app/tmp/pids'
   stdin_open: true
   tty: true
   volumes:
-  - "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock"
-  - "~/.ssh:/root/.ssh:ro"
-  - widget-factory_history:/usr/local/hist
-  - "${APDEV_WIDGET_FACTORY_DIR:?}:/app:rw,cached"
-  - "${APDEV_WIDGET_FACTORY_DIR:?}/ops/dev/.bashrc:/root/.bashrc:ro"
-  - "${APDEV_WIDGET_FACTORY_DIR:?}/ops/dev/.irbrc:/root/.irbrc:ro"
-  - widget-factory_rails_cache:/app/tmp/cache
-  - widget-factory_assets_builds:/app/assets/builds
-  - widget-factory_bundle_cache:/usr/local/bundle
-  - widget-factory_node_modules:/app/node_modules
+    - '/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock'
+    - '~/.ssh:/root/.ssh:ro'
+    - widget-factory_history:/usr/local/hist
+    - '${APDEV_WIDGET_FACTORY_DIR:?}:/app:rw,cached'
+    - '${APDEV_WIDGET_FACTORY_DIR:?}/ops/dev/.bashrc:/root/.bashrc:ro'
+    - '${APDEV_WIDGET_FACTORY_DIR:?}/ops/dev/.irbrc:/root/.irbrc:ro'
+    - widget-factory_rails_cache:/app/tmp/cache
+    - widget-factory_assets_builds:/app/assets/builds
+    - widget-factory_bundle_cache:/usr/local/bundle
+    - widget-factory_node_modules:/app/node_modules
   env_file:
-  - "${APDEV_WIDGET_FACTORY_SECRETS}"
-  - "${APDEV_WIDGET_FACTORY_DIR:?}/ops/env/base.env"
-  - "${APDEV_WIDGET_FACTORY_DIR:?}/ops/env/custom.env"
+    - '${APDEV_WIDGET_FACTORY_SECRETS}'
+    - '${APDEV_WIDGET_FACTORY_DIR:?}/ops/env/base.env'
+    - '${APDEV_WIDGET_FACTORY_DIR:?}/ops/env/custom.env'
   environment:
-    HISTFILE: "/usr/local/hist/.bash_history"
+    HISTFILE: '/usr/local/hist/.bash_history'
     EDITOR: nano
-    SSH_AUTH_SOCK: "/run/host-services/ssh-auth.sock"
-    BOOTSNAP_CACHE_DIR: "/usr/local/bundle/_bootsnap"
-    XDG_DATA_HOME: "/app/tmp/caches"
-    IRB_HISTFILE: "/usr/local/hst/.irb_history"
+    SSH_AUTH_SOCK: '/run/host-services/ssh-auth.sock'
+    BOOTSNAP_CACHE_DIR: '/usr/local/bundle/_bootsnap'
+    XDG_DATA_HOME: '/app/tmp/caches'
+    IRB_HISTFILE: '/usr/local/hst/.irb_history'
     DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
-    NPM_CONFIG_CACHE: "/app/node_modules/.npm-cache"
-    PSQL_HISTFILE: "/usr/local/hist/.psql_history"
+    NPM_CONFIG_CACHE: '/app/node_modules/.npm-cache'
+    PSQL_HISTFILE: '/usr/local/hist/.psql_history'
   depends_on:
     moxi-redis:
       condition: service_healthy
@@ -49,15 +49,22 @@ x-widget-factory: &1
       condition: service_started
     postgres14.5:
       condition: service_healthy
-  command: "./ops/bin/start-service.sh"
-  ports:
-  - 30013:3000
-services:
-  widget-factory: *1
-volumes:
-  widget-factory_history: 
-  widget-factory_rails_cache: 
-  widget-factory_bundle_cache: 
-  widget-factory_assets_builds: 
-  widget-factory_node_modules: 
 
+services:
+  widget-factory:
+    <<: *1
+    command: './ops/bin/start-service.sh'
+    ports:
+      - 30013:3000
+    depends_on:
+      widget-factory_sidekiq:
+        condition: service_started
+  widget-factory_sidekiq:
+    <<: *1
+    command: bundle exec sidekiq
+volumes:
+  widget-factory_history:
+  widget-factory_rails_cache:
+  widget-factory_bundle_cache:
+  widget-factory_assets_builds:
+  widget-factory_node_modules:

--- a/app/controllers/api/jwt_controller.rb
+++ b/app/controllers/api/jwt_controller.rb
@@ -3,7 +3,7 @@ class Api::JwtController < ApplicationController
 
   # POST /api/jwt
   def index
-    service = "#{Rails.application.config.base_profile_v2_service_url}/#{params[:uuid]}/validate_token"
+    service = "#{Rails.application.config.service_url[:profile_v2]}/#{params[:uuid]}/validate_token"
     sr = WmsResource::SecureRequest.new("profile")
     salt = "#{Base64.decode64(params[:password])}:#{params[:uuid]}"
     check = Digest::SHA512.hexdigest(Base64.encode64(Digest::SHA512.hexdigest(salt)))

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_user(uuid)
-    response = Base.profile_request("#{Rails.application.config.base_profile_service_url}/profile/#{uuid}")
+    response = Base.profile_request("#{Rails.application.config.service_url[:profile_v3]}/nucleus/profile/#{uuid}")
     user = response[:data][0]
     Session.set_user_on_session(user, session)
   end

--- a/app/models/resource/auth.rb
+++ b/app/models/resource/auth.rb
@@ -1,5 +1,5 @@
 class Resource::Auth < WmsResource::Resource
-  self.site = Rails.application.config.auth_service_url
+  self.site = Rails.application.config.service_url[:auth]
 
   def self.poll(session_id)
     Rails.cache.fetch(session_id, expires_in: 5.minutes, skip_nil: true) do

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -10,8 +10,10 @@ class Session
       member_role: user[:member_role],
       office_external_id: user[:office][:office_external_id],
       company_external_id: user[:company][:company_external_id],
+      company_uuid: user[:company][:company_uuid],
       board_external_id: user[:board][:board_external_id],
-      board_mls_id: user[:board][:mls_id]
+      board_mls_id: user[:board][:mls_id],
+      board_uuid: user[:board][:board_uuid],
     }
 
     session[:current_user] = h

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -14,6 +14,7 @@ class Session
       board_external_id: user[:board][:board_external_id],
       board_mls_id: user[:board][:mls_id],
       board_uuid: user[:board][:board_uuid],
+      office_uuid: user[:office][:office_uuid],
     }
 
     session[:current_user] = h

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,21 +1,21 @@
 class User
   def self.get_user(current_user_uuid)
-    response = Base.profile_request("#{Rails.application.config.base_profile_service_url}/profile/#{current_user_uuid}", {nucleus_view: "partner_extended"})
+    response = Base.profile_request("#{Rails.application.config.service_url[:profile_v3]}/nucleus/profile/#{current_user_uuid}", {nucleus_view: "partner_extended"})
     response[:data][0]
   end
 
   def self.get_office(current_user_office_uuid)
-    response = Base.profile_request("#{Rails.application.config.base_profile_service_url}/office/#{current_user_office_uuid}", {nucleus_view: "partner_extended"})
+    response = Base.profile_request("#{Rails.application.config.service_url[:profile_v3]}/nucleus/office/#{current_user_office_uuid}", {nucleus_view: "partner_extended"})
     response[:data][0]
   end
 
   def self.get_company(current_user_company_uuid)
-    response = Base.profile_request("#{Rails.application.config.base_profile_service_url}/company/#{current_user_company_uuid}", {nucleus_view: "partner_extended"})
+    response = Base.profile_request("#{Rails.application.config.service_url[:profile_v3]}/nucleus/company/#{current_user_company_uuid}", {nucleus_view: "partner_extended"})
     response[:data][0]
   end
 
   def self.get_board(current_user_board_uuid)
-    response = Base.profile_request("#{Rails.application.config.base_profile_service_url}/board/#{current_user_board_uuid}", {nucleus_view: "partner_extended"})
+    response = Base.profile_request("#{Rails.application.config.service_url[:profile_v3]}/nucleus/board/#{current_user_board_uuid}", {nucleus_view: "partner_extended"})
     response[:data][0]
   end
 end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -48,15 +48,15 @@ class Widget < ApplicationRecord
     save
   end
 
-  def log_event!(event_type, event_data = {})
-    return unless session[:current_user]
+  def log_event!(event_type, event_data = {}, user_uuid, company_uuid, board_uuid, office_uuid)
     EventLoggerJob.perform_async(
       event_type,
       component,
-      event_data,
-      session[:current_user][:uuid],
-      session[:current_user][:company_uuid],
-      session[:current_user][:board_uuid]
+      event_data.to_json,
+      user_uuid,
+      company_uuid,
+      board_uuid,
+      office_uuid
     )
   end
 

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -48,6 +48,18 @@ class Widget < ApplicationRecord
     save
   end
 
+  def log_event!(event_type, event_data = {})
+    return unless session[:current_user]
+    EventLoggerJob.perform_async(
+      event_type,
+      component,
+      event_data,
+      session[:current_user][:uuid],
+      session[:current_user][:company_uuid],
+      session[:current_user][:board_uuid]
+    )
+  end
+
   private
 
   def purge_logo

--- a/app/sidekiq/event_logger_job.rb
+++ b/app/sidekiq/event_logger_job.rb
@@ -1,9 +1,10 @@
 class EventLoggerJob
   include Sidekiq::Job
 
-  def perform(event_type, component, event_data, agent_uuid, company_uuid, board_uuid)
+  def perform(event_type, component, event_data, agent_uuid, company_uuid, board_uuid, office_uuid)
     event_data[:component] = component
     event_data[:board_uuid] = board_uuid
+    event_data[:office_uuid] = office_uuid
 
     @result = WmsSvcConsumer::Models::Event.log("nucleus_logging_event", "nucleus", {
     # TODO: Use widget events instead of nucleus events once they are added to the event service

--- a/app/sidekiq/event_logger_job.rb
+++ b/app/sidekiq/event_logger_job.rb
@@ -1,0 +1,17 @@
+class EventLoggerJob
+  include Sidekiq::Job
+
+  def perform(event_type, component, event_data, agent_uuid, company_uuid, board_uuid)
+    event_data[:component] = component
+    event_data[:board_uuid] = board_uuid
+
+    @result = WmsSvcConsumer::Models::Event.log("nucleus_logging_event", "nucleus", {
+    # TODO: Use widget events instead of nucleus events once they are added to the event service
+    # @result = WmsSvcConsumer::Models::Event.log(event_type, "widget-factory", {
+      agent_uuid: agent_uuid,
+      company_uuid: company_uuid,
+      event_data: event_data
+    })
+    raise StandardError, @result.errors.join(", ") if @result.errors.present?
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,15 @@ module WidgetFactory
     config.cache_store = :mem_cache_store, config.memcached_server, {namespace: "_widgetfactory_"}
     config.action_controller.perform_caching = true
     config.action_controller.page_cache_directory = Rails.root.join("public", "cached_pages")
+
+    config.before_initialize do
+      config.service_url = {
+        auth: ENV["auth_service_url"] || "#{config.base_service}/service/v1/auth",
+        profile_v2: ENV["profile_service_v2_url"] || "#{config.base_service}/service/profile/v2",
+        profile_v3: ENV["profile_service_v2_url"] || "#{config.base_service}/service/profile/v3",
+      }
+
+      config.active_job.queue_adapter = :sidekiq
+    end
   end
 end

--- a/config/environments/dev_integration.rb
+++ b/config/environments/dev_integration.rb
@@ -94,7 +94,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.base_profile_v2_service_url = "https://svc-devint.moxiworks.com/service/profile/v2"
-  config.base_profile_service_url = "https://svc-devint.moxiworks.com/service/profile/v3/nucleus"
-  config.auth_service_url = "https://svc-devint.moxiworks.com/service/v1/auth"
+  config.base_service = ENV["svc_base"] || "https://svc-devint.moxiworks.com"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,7 +68,5 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  config.base_profile_v2_service_url = "https://svc-devint.moxiworks.com/service/profile/v2"
-  config.base_profile_service_url = "https://svc-devint.moxiworks.com/service/profile/v3/nucleus"
-  config.auth_service_url = "https://svc-devint.moxiworks.com/service/v1/auth"
+  config.base_service = "https://svc-devint.moxiworks.com"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,7 +94,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.base_profile_v2_service_url = "https://svc.moxiworks.com/service/profile/v2"
-  config.base_profile_service_url = "https://svc.moxiworks.com/service/profile/v3/nucleus"
-  config.auth_service_url = "https://svc.moxiworks.com/service/v1/auth"
+  config.base_service = ENV["svc_base"] || "https://svc.moxiworks.com"
 end

--- a/config/environments/qa.rb
+++ b/config/environments/qa.rb
@@ -94,7 +94,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.base_profile_v2_service_url = "https://svc-qa.moxiworks.com/service/profile/v2"
-  config.base_profile_service_url = "https://svc-qa.moxiworks.com/service/profile/v3/nucleus"
-  config.auth_service_url = "https://svc-qa.moxiworks.com/service/v1/auth"
+  config.base_service = ENV["svc_base"] || "https://svc-qa.moxiworks.com"
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -94,7 +94,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.base_profile_v2_service_url = "https://svc-st.moxiworks.com/service/profile/v2"
-  config.base_profile_service_url = "https://svc-st.moxiworks.com/service/profile/v3/nucleus"
-  config.auth_service_url = "https://svc-st.moxiworks.com/service/v1/auth"
+  config.base_service = ENV["svc_base"] || "https://svc-st.moxiworks.com"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,7 +58,5 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  config.base_profile_v2_service_url = "https://svc-devint.moxiworks.com/service/profile/v2"
-  config.base_profile_service_url = "https://svc-devint.moxiworks.com/service/profile/v3/nucleus"
-  config.auth_service_url = "https://svc-devint.moxiworks.com/service/v1/auth"
+  config.base_service = ENV["svc_base"] || "https://svc-devint.moxiworks.com"
 end

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -94,7 +94,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.base_profile_v2_service_url = "https://svc-st.moxiworks.com/service/profile/v2"
-  config.base_profile_service_url = "https://svc-st.moxiworks.com/service/profile/v3/nucleus"
-  config.auth_service_url = "https://svc-st.moxiworks.com/service/v1/auth"
+  config.base_service = ENV["svc_base"] || "https://svc-st.moxiworks.com"
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,19 @@
+require "sidekiq"
+require "sidekiq/web"
+
+redis_conf = YAML.load_file(Rails.root.join("config", "redis.yml"))[Rails.env]
+redis_url = ENV.fetch("REDIS_URL") { "redis://#{redis_conf["host"]}:#{redis_conf["port"]}/#{redis_conf["database"]}" }
+
+Sidekiq.strict_args!
+
+Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+  username == "wsccoord" && password == "blueprint"
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = {url: redis_url}
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {url: redis_url}
+end

--- a/config/initializers/wms_svc_consumer.rb
+++ b/config/initializers/wms_svc_consumer.rb
@@ -1,0 +1,6 @@
+require "yaml"
+require "wms_svc_consumer/wms_record"
+
+WmsSvcConsumer::Base.site = "#{Rails.application.config.base_service}/service/v1/profile"
+WmsSvcConsumer::Models::Event.site = "#{Rails.application.config.base_service}/service/event/v1"
+WmsSvcConsumer::Models::Message.site = "#{Rails.application.config.base_service}/service/v1/message"

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,0 +1,31 @@
+defaults: &defaults
+  host: 127.0.0.1
+  port: 6379
+  database: 0
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+  database: 1
+
+staging:
+  <<: *defaults
+  host: widget-factory-prs-st.redis.moxi.bz
+
+dev_integration:
+  <<: *defaults
+  host: widget-factory-prs-devint.redis.moxi.bz
+
+qa:
+  <<: *defaults
+  host: widget-factory-prs-qa.redis.moxi.bz
+
+uat:
+  <<: *defaults
+  host: widget-factory-prs-uat.redis.moxi.bz
+
+production:
+  <<: *defaults
+  host: widget-factory-prs.redis.moxi.bz

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,11 @@ Rails.application.routes.draw do
   get "check" => "status#check"
   get "clear_cache" => "status#clear_cache"
 
+  if defined?(Sidekiq)
+    require "sidekiq/web"
+    mount Sidekiq::Web => "/sidekiq"
+  end
+
   namespace :api do
     resources :widgets
     resources :user_widgets

--- a/test/controllers/api/jwt_controller_test.rb
+++ b/test/controllers/api/jwt_controller_test.rb
@@ -18,6 +18,6 @@ class Api::JwtControllerTest < ActionController::TestCase
   end
 
   def service_url(uuid)
-    "#{Rails.application.config.base_profile_v2_service_url}/#{uuid}/validate_token"
+    "#{Rails.application.config.service_url[:profile_v2]}/#{uuid}/validate_token"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,9 +25,9 @@ knapsack_adapter.set_test_helper_path(__FILE__)
 module JwtHelper
   def get_jwt
     # Stub authentication request
-    stub_request(:post, "#{Rails.application.config.base_profile_v2_service_url}/1234/validate_token").to_return(status: 200)
+    stub_request(:post, "#{Rails.application.config.service_url[:profile_v2]}/1234/validate_token").to_return(status: 200)
     # Stub future requests to get user profile
-    stub_request(:get, "#{Rails.application.config.base_profile_service_url}/profile/1234")
+    stub_request(:get, "#{Rails.application.config.service_url[:profile_v3]}/nucleus/profile/1234")
       .with(query: hash_including({}))
       .to_return(status: 200, body: {data: [{uuid: "1234", office: {}, company: {}, board: {}}]}.to_json)
     post api_jwt_path, params: {uuid: "1234", password: Base64.encode64("password")}


### PR DESCRIPTION
## Description

- Modified the environment configs to set `config.base_service` like nucleus and other apps.  The `config.service_url` is then set in `application.config`.
- Added sidekiq:
  - Added the sidekiq gem.  I did not use the enterprise gem because I don't think we'll need periodic jobs.
  - Created the necessary initializer.
  - Added a `widget-factory_sidekiq` service to `apdev.yml`.
  - Added the route for the web UI.
  - Created `redis.yml` (mostly copied from nucleus).  I created a ticket for ops to add the various environment instances.
  - Added `config.active_job.queue_adapter = :sidekiq` to the application config.
- Created an initializer for `wms_svc_consumer` to set the service URLs (e.g. for the event service).
- Created an `EventLoggerJob`.  The actual event service logging part is still a work in progress.
- Added `company_uuid` and `board_uuid` to the session so those can be attached to logged events.
- Added a `Widget.log_event!` method that calls `EventLoggerJob.perform_async`.  This will likely change eventually.

@aroop The EventLoggerJob processes successfully for me locally.  Is there anything missing to ensure sidekiq will work once deployed?  Nucleus has a `run_eks_sidekiq.sh` script, but I wasn't sure if that was needed here.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-152
