### PR TITLE
OT-158 - Show widgets by default until user explicitly removes them

### DIFF
--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -152,10 +152,12 @@ setTimeout(() => {
 
 const menu = root.querySelector("mx-menu");
 const menuButton = root.querySelector(".menu-button");
-if (menu && menuButton) menu.anchorEl = menuButton;
-menuButton.addEventListener('click', () => {
-  logEvent('widget_open_menu');
-});
+if (menu && menuButton) {
+  menu.anchorEl = menuButton;
+  menuButton.addEventListener('click', () => {
+    logEvent('widget_open_menu');
+  });
+}
 
 const menuItems = root.querySelectorAll("mx-menu-item");
 if (menuItems.length) {

--- a/app/components/hurdlr/hurdlr_component.rb
+++ b/app/components/hurdlr/hurdlr_component.rb
@@ -41,7 +41,7 @@ class Hurdlr::HurdlrComponent < ViewComponent::Base
       message = e.message || "Unknown error getting Hurdlr data"
       @widget.log_event!(
         'widget_error',
-        {message: message, endpoint: endpoint, payload: payload},
+        {message: message, endpoint: request.env[:REQUEST_URI]},
         session.dig(:current_user, :uuid),
         session.dig(:current_user, :company_uuid),
         session.dig(:current_user, :board_uuid),

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -217,10 +217,12 @@ if (apiError !== '') console.error(apiError);
 const root = document.querySelector('.list_trac');
 const menu = root.querySelector("mx-menu");
 const menuButton = root.querySelector(".menu-button");
-if (menu && menuButton) menu.anchorEl = menuButton;
-menuButton.addEventListener('click', () => {
-  logEvent('widget_open_menu');
-});
+if (menu && menuButton) {
+  menu.anchorEl = menuButton;
+  menuButton.addEventListener('click', () => {
+    logEvent('widget_open_menu');
+  });
+}
 
 const expandButton = root.querySelector(".expand-button");
 if (expandButton) expandButton.addEventListener("click", expand);

--- a/app/components/list_trac/list_trac_component.rb
+++ b/app/components/list_trac/list_trac_component.rb
@@ -18,6 +18,14 @@ class ListTrac::ListTracComponent < ViewComponent::Base
     rescue => e
       @error = e.message
       @error_with_api = e.is_a?(RestClient::Exception) || e.is_a?(SocketError)
+      @widget.log_event!(
+        'widget_error',
+        {message: e.message, endpoint: request.env[:REQUEST_URI]},
+        session.dig(:current_user, :uuid),
+        session.dig(:current_user, :company_uuid),
+        session.dig(:current_user, :board_uuid),
+        session.dig(:current_user, :office_uuid)  
+      )
     end
   end
 
@@ -29,27 +37,15 @@ class ListTrac::ListTracComponent < ViewComponent::Base
       # TrackingValues: "364512302",
       ResponseType: "summary"
     }
-    begin
-      response = RestClient::Request.execute(
-        method: :get,
-        timeout: 10,
-        url: "https://b2b.listtrac.com/RESO/OData/InternetTracking?#{params.to_query}",
-        verify_ssl: false
-      )
-      json = JSON.parse(response, symbolize_names: true)
-      [json[:value] || [], (json[:status] == "ok") ? nil : json[:description]]
-    rescue RestClient::ExceptionWithResponse => e
-      message = e.message || "Unknown error getting listings from ListTrac API"
-      @widget.log_event!(
-        'widget_error',
-        {message: message, endpoint: endpoint, payload: payload},
-        session.dig(:current_user, :uuid),
-        session.dig(:current_user, :company_uuid),
-        session.dig(:current_user, :board_uuid),
-        session.dig(:current_user, :office_uuid)  
-      )
-      [{}, message]
-    end
+    response = RestClient::Request.execute(
+      method: :get,
+      timeout: 10,
+      url: "https://b2b.listtrac.com/RESO/OData/InternetTracking?#{params.to_query}",
+      verify_ssl: false
+    )
+    json = JSON.parse(response, symbolize_names: true)
+    raise json[:description] if json[:status] != "ok"
+    json[:value] || []
   end
 
   def token

--- a/app/components/tips/tips_component.html.erb
+++ b/app/components/tips/tips_component.html.erb
@@ -56,10 +56,12 @@ window.addEventListener("message", (e) => {
 function initMenu() {
   const menu = root.querySelector("mx-menu");
   const menuButton = root.querySelector(".menu-button");
-  if (menu && menuButton) menu.anchorEl = menuButton;
-  menuButton.addEventListener('click', () => {
-    logEvent('widget_open_menu');
-  });
+  if (menu && menuButton) {
+    menu.anchorEl = menuButton;
+    menuButton.addEventListener('click', () => {
+      logEvent('widget_open_menu');
+    });
+  }
   
   const menuItems = root.querySelectorAll("mx-menu-item");
   if (menuItems.length) {

--- a/app/components/widget_panel/widget_panel_component.html.erb
+++ b/app/components/widget_panel/widget_panel_component.html.erb
@@ -10,19 +10,19 @@
       <span class="add-remove-widgets">Widgets</span>
     </mx-button>
   </header>
-  <% if @user_widgets.any? %>
+  <% if @widgets.any? %>
     <p id="reorder-help" class="sr-only">
       Activate the reorder button and use the arrow keys to reorder the list. Press Escape or Tab to cancel the reordering.
     </p>
     <ol class="widget-grid overflow-hidden md:pb-96" aria-labelledby="widgets-heading">
-      <% @user_widgets.each do |user_widget| %>
-        <li data-widget-id="<%= user_widget.widget.id %>" data-widget-component="<%= user_widget.widget.component %>" data-widget-name="<%= user_widget.widget.name %>">
-          <%= render user_widget.widget.view_component.new %>
+      <% @widgets.each do |widget| %>
+        <li data-widget-id="<%= widget.id %>" data-widget-component="<%= widget.component %>" data-widget-name="<%= widget.name %>">
+          <%= render widget.view_component.new %>
         </li>
       <% end %>
     </ol>
   <% end %>
-  <div class="empty-state text-center <%= @user_widgets.any? ? "hidden" : "" %>">
+  <div class="empty-state text-center <%= @widgets.any? ? "hidden" : "" %>">
     <div class="text-h5 my-0 mt-24 mb-8">
       No widgets to show yet
     </div>
@@ -278,8 +278,8 @@ function reorderWidgetElements() {
       (a, b) => getOrder(a) - getOrder(b)
     );
     orderedWidgets.forEach(widget => draggedWidget.parentElement.appendChild(widget));
-    updateUserWidget();
-    logEvent('widget_reorder_widgets');
+    updateUserWidgets(orderedWidgets.map(w => w.dataset.widgetId));
+    logEvent('widget_reorder_widgets', null, draggedWidget.dataset.widgetComponent);
     overWidget = null;
   }
   resetWidgetOrderAttributes();
@@ -308,12 +308,11 @@ function getPointer(e) {
   }
 }
 
-function updateUserWidget() {
+function updateUserWidgets(orderedWidgetIds) {
   if (!draggedWidget) return;
-  const widgetId = draggedWidget.dataset.widgetId;
-  _fetch(`/api/user_widgets/${widgetId}?session_id=${SESSION_ID}`, {
+  _fetch(`/api/user_widgets/?session_id=${SESSION_ID}`, {
     method: 'PATCH',
-    body: JSON.stringify({ row_order_position: getOrder(draggedWidget) })
+    body: JSON.stringify({ widget_ids: orderedWidgetIds })
   });
 }
 function destroyUserWidget(widgetId) {
@@ -337,7 +336,7 @@ async function _fetch(url, options) {
     <div slot="header-left">Library</div>
     <div class="widget-library-grid">
       <% @active_widgets.each do |widget| %>
-        <% added = @user_widgets.find_by(widget: widget).present? %>
+        <% added = @widgets.include?(widget) %>
         <div data-widget-id="<%= widget.id %>" class="px-16 pt-16 pb-24 bg-white rounded-lg">
           <div class="px-8 mb-20">
             <mx-button btn-type="text" icon="icon icon-plus-circle" class="add-button <%= added ? "hidden" : "" %>">
@@ -417,7 +416,7 @@ addButtons.forEach((button) => {
     addButton.querySelector('.button-text').innerText = 'Adding widget'
     addButton.disabled = true;
     try {
-      await createUserWidget(widgetId);
+      await restoreUserWidget(widgetId);
       // Replace add button with remove button
       addButton.classList.add('hidden')
       removeButtonWrapper.classList.remove('hidden');
@@ -460,22 +459,21 @@ removeButtons.forEach((button) => {
   });
 });
 
-function logEvent(eventType, eventData) {
+function logEvent(eventType, eventData, component = 'widget_panel') {
   _fetch(`/api/events/?session_id=${SESSION_ID}`, {
     method: 'POST',
     body: JSON.stringify({
       event_type: eventType,
       event_data: eventData,
-      component: 'widget_panel',
+      component,
      })
   });
 }
 
-function createUserWidget(widgetId) {
+function restoreUserWidget(widgetId) {
   logEvent('widget_add_via_library');
-  return _fetch(`/api/user_widgets?session_id=${SESSION_ID}`, {
+  return _fetch(`/api/user_widgets/${widgetId}/restore?session_id=${SESSION_ID}`, {
     method: 'POST',
-    body: JSON.stringify({ widget_id: widgetId, row_order_position: 'last' })
   })
 }
 function destroyUserWidget(widgetId) {

--- a/app/components/widget_panel/widget_panel_component.rb
+++ b/app/components/widget_panel/widget_panel_component.rb
@@ -7,9 +7,13 @@ class WidgetPanel::WidgetPanelComponent < ViewComponent::Base
     # Ensure that a view component exists for each widget (in case a component is removed or is on another branch)
     @active_widgets = @active_widgets.filter { |w| w.view_component.present? }
     @user_uuid = session.dig(:current_user, :uuid)
-    @user_widgets = UserWidget.where(user_uuid: @user_uuid)
-      .where(widgets: @active_widgets)
-      .joins(:widget)
-      .rank(:row_order)
+    user_removed_widget_ids = UserWidget.where(user_uuid: @user_uuid, removed: true).pluck(:widget_id)
+    user_restored_widget_ids = UserWidget.where(user_uuid: @user_uuid, removed: false).pluck(:widget_id)
+    @widgets = Widget
+      .joins("LEFT OUTER JOIN user_widgets ON user_widgets.widget_id = widgets.id AND user_widgets.user_uuid = '#{@user_uuid}'")
+      .where(id: @active_widgets.pluck(:id))
+      .where.not(id: user_removed_widget_ids)
+      .or(Widget.where(id: user_restored_widget_ids))
+      .order('user_widgets.row_order ASC NULLS LAST')
   end
 end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -5,6 +5,8 @@ class Widget < ApplicationRecord
   attribute :remove_logo, :boolean
   after_save :purge_logo, if: :remove_logo
 
+  has_many :user_widgets, dependent: :destroy
+
   scope :activated_widgets, -> {
     where(status: Widget.statuses[:ready], activation_date: ..Time.zone.now)
       .or(where(status: Widget.statuses[:ready], activation_date: nil))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,10 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :widgets
-    resources :user_widgets
     post "events" => "events#create"
+    patch "user_widgets", to: "user_widgets#update_order"
+    delete "user_widgets/:id", to: "user_widgets#destroy", as: :destroy_user_widget
+    post "user_widgets/:id/restore", to: "user_widgets#restore", as: :restore_user_widget
     post "jwt" => "jwt#index"
   end
 

--- a/db/migrate/20230419155013_add_removed_to_user_widgets.rb
+++ b/db/migrate/20230419155013_add_removed_to_user_widgets.rb
@@ -1,0 +1,5 @@
+class AddRemovedToUserWidgets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_widgets, :removed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_28_134804) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_19_155013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_134804) do
     t.integer "row_order"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "removed", default: false
     t.index ["widget_id"], name: "index_user_widgets_on_widget_id"
   end
 

--- a/test/controllers/api/widgets_controller_test.rb
+++ b/test/controllers/api/widgets_controller_test.rb
@@ -5,7 +5,7 @@ class Api::WidgetsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     response_body = JSON.parse(response.body)
-    assert_equal 2, response_body.length
+    assert_equal 3, response_body.length
   end
 
   test "should get single widget" do

--- a/test/fixtures/user_widgets.yml
+++ b/test/fixtures/user_widgets.yml
@@ -1,11 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  user_uuid: MyString
+  user_uuid: 1234
   widget: one
   row_order: 1
+  removed: false
 
 two:
-  user_uuid: MyString
+  user_uuid: 1234
   widget: two
   row_order: 1
+  removed: true

--- a/test/fixtures/widgets.yml
+++ b/test/fixtures/widgets.yml
@@ -21,3 +21,14 @@ two:
   activation_date: 2023-01-23 09:04:27
   internal: false
   updated_by: MyString
+
+three:
+  component: widget_three
+  partner: MyString
+  name: Widget Three
+  description: MyString
+  logo_link_url: MyString
+  status: draft
+  activation_date: 2023-01-23 09:04:27
+  internal: false
+  updated_by: MyString


### PR DESCRIPTION
## Description

This changes the purpose and behavior of the `UserWidget` model.

Before, a user would start with no widgets.  They would add each widget, creating `UserWidget` records, which could also be reordered.  Removing a widget from their dashboard meant destroying the `UserWidget` records.

The problem with that is that there are thousands of users, and we want all users to start with all widgets by default.

With this PR, widgets are now shown by default unless explicitly removed by the user.  When they remove a widget from their dashboard, a `UserWidget` record is created/updated with the `removed` column set to `true`.  If the user reorders the widgets, then a `UserWidget` record is created/updated for each widget with the appropriate `row_order` value.  The `UserWidget` records are never actually deleted from the table.

I also fixed a few things that were broken from the last PR (logging events):
- Fixed some console errors when opening the widget library because the menu buttons are not present in library mode
- Fixed the list_trac component error logging.  I didn't catch this when I rebased previously for the last PR.
- Fixed some bad event data being logged in the hurdlr and list_trac components.  I'm not sure where I saw that `endpoint` and `payload` were globals, but they're not.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-158

## Validation Steps
- Verify that all activated widgets are shown until explicitly removed by the user.
- Verify that removing a widget works as expected.
- Verify that restoring a widget works as expected.
- Verify that reordering widgets works as expected.
