### PR TITLE
OT-161 - Fix active widget filtering

### DIFF
--- a/app/components/widget_panel/widget_panel_component.rb
+++ b/app/components/widget_panel/widget_panel_component.rb
@@ -8,12 +8,10 @@ class WidgetPanel::WidgetPanelComponent < ViewComponent::Base
     @active_widgets = @active_widgets.filter { |w| w.view_component.present? }
     @user_uuid = session.dig(:current_user, :uuid)
     user_removed_widget_ids = UserWidget.where(user_uuid: @user_uuid, removed: true).pluck(:widget_id)
-    user_restored_widget_ids = UserWidget.where(user_uuid: @user_uuid, removed: false).pluck(:widget_id)
+    visible_widget_ids = @active_widgets.pluck(:id) - user_removed_widget_ids
     @widgets = Widget
       .joins("LEFT OUTER JOIN user_widgets ON user_widgets.widget_id = widgets.id AND user_widgets.user_uuid = '#{@user_uuid}'")
-      .where(id: @active_widgets.pluck(:id))
-      .where.not(id: user_removed_widget_ids)
-      .or(Widget.where(id: user_restored_widget_ids))
+      .where(id: visible_widget_ids)
       .order('user_widgets.row_order ASC NULLS LAST')
   end
 end


### PR DESCRIPTION
## Description

This fixes an issue with the `where` and `or` chaining I was using to try to get active widgets that had not been removed by the user.  The user would be shown a deactivated widget if they had previously removed and then restored the widget to their dashboard.

I've instead subtracted the removed widget IDs from an array of active widget IDs and used that array in a single `where` clause, so it's much simpler and works perfectly now.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-161

## Validation Steps
Remove a widget from a user's dashboard and then add it back.  Deactivate that widget from the admin page.  The widget should not appear on the user's dashboard.
