### PR TITLE
OT-161 - Do not raise exception if API error logging fails

### DIFF
--- a/app/components/hurdlr/hurdlr_component.rb
+++ b/app/components/hurdlr/hurdlr_component.rb
@@ -46,7 +46,7 @@ class Hurdlr::HurdlrComponent < ViewComponent::Base
         session.dig(:current_user, :company_uuid),
         session.dig(:current_user, :board_uuid),
         session.dig(:current_user, :office_uuid)  
-      )
+      ) rescue nil
       [{}, message]
     end
   end

--- a/app/components/list_trac/list_trac_component.rb
+++ b/app/components/list_trac/list_trac_component.rb
@@ -25,7 +25,7 @@ class ListTrac::ListTracComponent < ViewComponent::Base
         session.dig(:current_user, :company_uuid),
         session.dig(:current_user, :board_uuid),
         session.dig(:current_user, :office_uuid)  
-      )
+      ) rescue nil
     end
   end
 


### PR DESCRIPTION
## Description

If there is an error from a partner API, _and_ logging of that error fails for some reason (e.g. because the EventLoggerJob does not work in QA right now), then the component should still render.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-161?focusedCommentId=707824 (@alexsheverenko's comment)
