### PR TITLE
Factor out a base ApplicationComponent

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,0 +1,29 @@
+class ApplicationComponent < ViewComponent::Base
+  def initialize(library_mode: false)
+    @library_mode = library_mode
+  end
+
+  def before_render
+    @library_mode ||= params[:library_mode]
+    @error = nil
+    @error_with_api = false
+    begin
+      component_name = self.class.to_s.underscore.split("/").first
+      @widget = Widget.find_by(component: component_name)
+    rescue => e
+      @error = e.message
+      log_error(e)
+    end
+  end
+
+  def log_error(e)
+    @widget.log_event!(
+      "widget_error",
+      {message: e.message, endpoint: request.env[:REQUEST_URI]},
+      session.dig(:current_user, :uuid),
+      session.dig(:current_user, :company_uuid),
+      session.dig(:current_user, :board_uuid),
+      session.dig(:current_user, :office_uuid)  
+    ) rescue nil
+  end
+end

--- a/app/components/tips/tips_component.rb
+++ b/app/components/tips/tips_component.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-class Tips::TipsComponent < ViewComponent::Base
-  def initialize(library_mode: false)
-    @library_mode = library_mode
-  end
-
+class Tips::TipsComponent < ApplicationComponent
   def before_render
-    @library_mode ||= params[:library_mode]
+    super
+    return if @error.present?
     demo_params = {
       "description" => "Utilizing online marketing platforms, such as MoxiPromote, can help you reach a wider audience and generate leads.",
       "cta_label" => "Learn more",
@@ -19,6 +16,5 @@ class Tips::TipsComponent < ViewComponent::Base
     @cta_label = tips_params["cta_label"]
     @cta_url = tips_params["cta_url"]
     @bg = tips_params["bg"] || "1"
-    @widget = Widget.find_by(component: "tips")
   end
 end


### PR DESCRIPTION
## Description

This moves some of the common component ruby code (e.g. the `initialize` method and error logging) to a base `ApplicationComponent`.

I'm still holding off on factoring out the common javascript until we've truly figured out how extensive the "widget framework" needs to be for third party developers.