### PR TITLE
Do not request list_trac token twice

### DIFF
--- a/app/components/list_trac/list_trac_component.rb
+++ b/app/components/list_trac/list_trac_component.rb
@@ -18,7 +18,7 @@ class ListTrac::ListTracComponent < ApplicationComponent
 
   def agent_listings
     params = {
-      access_token: token,
+      access_token: @token,
       TrackingType: "Agent",
       TrackingValues: session[:current_user][:mls_number],
       # TrackingValues: "364512302",


### PR DESCRIPTION
## Description

I was getting an intermittent "Token is not valid" error from the ListTrac API, particularly right after adding the widget from the library modal.  I realized that the component was requesting two tokens from ListTrac on every render (once to set `@token`, and once to request the `agent_listings`).  I updated the `agent_listings` method to use the previously set instance variable, and this seems to have fixed it.

This is not critical to the upcoming prod deployment (nor should it be a risky change if merged and deployed).

## Validation Steps
Remove and add the ListTrac widget via the library modal, and verify that there is no "Token is not valid" error logged to the console in dev tools.
