### PR TITLE
Remove widget_panel row (and internal column) from widgets table

### DIFF
--- a/app/components/widget_panel/widget_panel_component.rb
+++ b/app/components/widget_panel/widget_panel_component.rb
@@ -3,7 +3,7 @@
 class WidgetPanel::WidgetPanelComponent < ViewComponent::Base
   def before_render
     permitted_components = params[:components].split(",").map(&:to_sym)
-    @active_widgets = Widget.activated_widgets.where(internal: false, component: permitted_components)
+    @active_widgets = Widget.activated_widgets.where(component: permitted_components)
     # Ensure that a view component exists for each widget (in case a component is removed or is on another branch)
     @active_widgets = @active_widgets.filter { |w| w.view_component.present? }
     @user_uuid = session.dig(:current_user, :uuid)
@@ -12,14 +12,14 @@ class WidgetPanel::WidgetPanelComponent < ViewComponent::Base
     @widgets = Widget
       .joins("LEFT OUTER JOIN user_widgets ON user_widgets.widget_id = widgets.id AND user_widgets.user_uuid = '#{@user_uuid}'")
       .where(id: visible_widget_ids)
-      .order('user_widgets.row_order ASC NULLS LAST')
+      .order("user_widgets.row_order ASC NULLS LAST")
     log_load_events unless current_page?(component_named_expanded_path)
   end
 
   def log_load_events
     @widgets.each do |widget|
       widget.log_event!(
-        'widget_dashboard_load',
+        "widget_dashboard_load",
         {},
         session.dig(:current_user, :uuid),
         session.dig(:current_user, :company_uuid),

--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -3,7 +3,7 @@ class Api::WidgetsController < ApplicationController
 
   # GET /api/widgets
   def index
-    @widgets = Widget.where(internal: false)
+    @widgets = Widget.all
     render json: @widgets
   end
 

--- a/db/migrate/20230601140449_delete_widget_panel_widget.rb
+++ b/db/migrate/20230601140449_delete_widget_panel_widget.rb
@@ -1,0 +1,6 @@
+class DeleteWidgetPanelWidget < ActiveRecord::Migration[7.0]
+  def change
+    # There was no need to have a widget record for the widget panel (this has been removed from seeds.rb)
+    Widget.where(component: "widget_panel").delete_all
+  end
+end

--- a/db/migrate/20230601141140_remove_interal_from_widgets.rb
+++ b/db/migrate/20230601141140_remove_interal_from_widgets.rb
@@ -1,0 +1,8 @@
+class RemoveInteralFromWidgets < ActiveRecord::Migration[7.0]
+  def change
+    # This was only used to hide the widget panel from the widget list, which really did not need
+    # to be added to the database in the first place.  This column would also add confusion since
+    # we will soon have internal widgets (e.g. hurdlr, list_trac, tips) vs. external widgets (in an iframe).
+    remove_column :widgets, :internal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_19_155013) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_01_141140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,7 +70,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_19_155013) do
     t.string "logo_link_url"
     t.string "status"
     t.datetime "activation_date"
-    t.boolean "internal"
     t.string "updated_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,23 +1,12 @@
 Widget.create([
   {
-    component: "widget_panel",
-    partner: "",
-    name: "My Widgets",
-    description: "",
-    logo_link_url: "",
-    status: "ready",
-    activation_date: Time.zone.now,
-    internal: true
-  },
-  {
     component: "hurdlr",
     partner: "Hurdlr",
     name: "Profit + Loss",
     description: "Get a quick glance of your profit and loss statement.",
     logo_link_url: "https://prod-integration.hurdlr.com/saml/assertion/stellar",
     status: "ready",
-    activation_date: Time.zone.now,
-    internal: false
+    activation_date: Time.zone.now
   },
   {
     component: "list_trac",
@@ -26,8 +15,7 @@ Widget.create([
     description: "View and track online activity for your listings.",
     logo_link_url: "https://stellar.sso.listtrac.com/Account/SingleSignOn",
     status: "ready",
-    activation_date: Time.zone.now,
-    internal: false
+    activation_date: Time.zone.now
   },
   {
     component: "tips",
@@ -36,8 +24,7 @@ Widget.create([
     description: "Stay ahead of the game with our weekly real estate tip! Stay up-to-date on industry trends to grow your business in just a few minutes a week.",
     logo_link_url: "",
     status: "ready",
-    activation_date: Time.zone.now,
-    internal: false
+    activation_date: Time.zone.now
   }
 ])
 

--- a/test/fixtures/widgets.yml
+++ b/test/fixtures/widgets.yml
@@ -8,7 +8,6 @@ one:
   logo_link_url: MyString
   status: ready
   activation_date: 2023-01-23 09:04:27
-  internal: false
   updated_by: MyString
 
 two:
@@ -19,7 +18,6 @@ two:
   logo_link_url: MyString
   status: draft
   activation_date: 2023-01-23 09:04:27
-  internal: false
   updated_by: MyString
 
 three:
@@ -30,5 +28,4 @@ three:
   logo_link_url: MyString
   status: draft
   activation_date: 2023-01-23 09:04:27
-  internal: false
   updated_by: MyString


### PR DESCRIPTION
## Description

This PR deletes the row from the `widgets` tablet that is associated with the `widget_panel` component.  The widget panel isn't really a widget; it's just a component, so I think it makes more sense to just leave it out of the table.  I'm not sure why I thought to include it in the first place.

This also eliminates the need for the `internal` column, which was only used to exclude the widget panel from queries for actual widgets.  That column would only add confusion once we add "external" widgets that are hosted externally.

I would rather make this change now before we've officially released widgets since I'm destroying a table column.

## Validation Steps
Verify the widget panel still renders in nucleus.  Verify the widget panel does not appear in the widget admin list in nucleus.
