### PR TITLE
Add test files for the new inline and expanded widget components

### DIFF
--- a/app/components/inline_widget_component.html.erb
+++ b/app/components/inline_widget_component.html.erb
@@ -11,8 +11,8 @@
 
   <div class="relative flex flex-1">
     <%= content %>
-    <%= render "error" if @error.present? %>
-    <%= render "spinner" %>
+    <%= render "component/error" if @error.present? %>
+    <%= render "component/spinner" %>
   </div>
 
   <% wrap_logo_with_link = !@library_mode && @widget.logo_link_url.present? %>

--- a/test/components/expanded_widget_component_test.rb
+++ b/test/components/expanded_widget_component_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ExpandedWidgetComponentTest < ViewComponent::TestCase
+  def setup
+    @widget = Widget.new(
+      name: "Test Widget",
+      component: "test_widget",
+      partner: "MoxiWorks",
+      logo_link_url: "https://moxiworks.com"
+    )
+    @widget.logo.attach(io: File.open(Rails.root.join("test", "fixtures", "files", "logo.png")), filename: "logo.png", content_type: "image/png")
+  end
+
+  def test_component_renders_content
+    render_inline(ExpandedWidgetComponent.new(widget: @widget)) { "Content" }
+    assert_text "Content"
+  end
+
+  def test_component_renders_default_heading
+    render_inline(ExpandedWidgetComponent.new(widget: @widget))
+    assert_selector "[slot='header-left']", text: @widget[:name]
+  end
+
+  def test_component_renders_custom_heading
+    render_inline(ExpandedWidgetComponent.new(widget: @widget, modal_heading: "Custom Heading"))
+    assert_selector "[slot='header-left']", text: "Custom Heading"
+  end
+
+  def test_component_renders_logo
+    render_inline(ExpandedWidgetComponent.new(widget: @widget))
+    assert_selector("img#logo[src*='logo.png'][alt='#{@widget[:partner]}']")
+  end
+
+  def test_component_render_logo_link
+    render_inline(ExpandedWidgetComponent.new(widget: @widget))
+    assert_selector("a[href='#{@widget[:logo_link_url]}']")
+  end
+end

--- a/test/components/hurdlr/hurdlr_component_test.rb
+++ b/test/components/hurdlr/hurdlr_component_test.rb
@@ -9,29 +9,11 @@ class Hurdlr::HurdlrComponentTest < ViewComponent::TestCase
     @error = nil
   end
 
-  def test_component_renders_name
-    assert_includes(
-      rendered.css("#heading").to_html,
-      @widget.name
-    )
-  end
-
   def test_component_renders_metrics_table
     # Rows are added via JavaScript, so we will just check for the headers
     table = rendered.css("table").to_html
     assert_includes(table, "Metric")
     assert_includes(table, "Amount")
-  end
-
-  def test_component_renders_logo
-    assert_includes(
-      rendered.css("img#logo").to_html,
-      "logo.png"
-    )
-    assert_includes(
-      rendered.css("img#logo").to_html,
-      "alt=\"#{@widget.partner}\""
-    )
   end
 
   def test_component_renders_signup
@@ -40,26 +22,6 @@ class Hurdlr::HurdlrComponentTest < ViewComponent::TestCase
         rendered.to_html,
         "Sign up for Hurdlr"
       )
-    end
-  end
-
-  def test_component_renders_error
-    instance_variable_set(:@error, "unknown error") do
-      assert_includes(
-        rendered.to_html,
-        "working on fixing things"
-      )
-    end
-  end
-
-  def test_component_renders_error_with_api
-    instance_variable_set(:@error, "unknown error") do
-      instance_variable_set(:@error_with_api, true) do
-        assert_includes(
-          rendered.to_html,
-          "trouble connecting to Hurdlr"
-        )
-      end
     end
   end
 

--- a/test/components/inline_widget_component_test.rb
+++ b/test/components/inline_widget_component_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InlineWidgetComponentTest < ViewComponent::TestCase
+  def setup
+    @widget = Widget.new(
+      name: "Test Widget",
+      component: "test_widget",
+      partner: "MoxiWorks",
+      logo_link_url: "https://moxiworks.com"
+    )
+    @widget.logo.attach(io: File.open(Rails.root.join("test", "fixtures", "files", "logo.png")), filename: "logo.png", content_type: "image/png")
+    @error = nil
+  end
+
+  def test_component_renders_content
+    render_inline(InlineWidgetComponent.new(widget: @widget)) { "Content" }
+    assert_text "Content"
+  end
+
+  def test_component_renders_name
+    render_inline(InlineWidgetComponent.new(widget: @widget))
+    assert_selector "header", text: @widget[:name]
+  end
+
+  def test_component_renders_logo
+    render_inline(InlineWidgetComponent.new(widget: @widget))
+    assert_selector("img#logo[src*='logo.png'][alt='#{@widget[:partner]}']")
+  end
+
+  def test_component_render_logo_link
+    render_inline(InlineWidgetComponent.new(widget: @widget))
+    assert_selector("a[href='#{@widget[:logo_link_url]}']")
+  end
+
+  def test_component_renders_error
+    render_inline(InlineWidgetComponent.new(widget: @widget, error: "unknown error"))
+    assert_text "working on fixing things"
+  end
+
+  def test_component_renders_error_with_api
+    render_inline(InlineWidgetComponent.new(widget: @widget, error: "unknown error"))
+    instance_variable_set(:@error_with_api, true) do
+      assert_text "trouble connecting to #{@widget[:partner]}}"
+    end
+  end
+
+  def test_component_renders_expand_button
+    expand_button = "button[aria-label='Expand widget']"
+    render_inline(InlineWidgetComponent.new(widget: @widget))
+    assert_no_selector expand_button
+    render_inline(InlineWidgetComponent.new(widget: @widget, expand_url: "https://moxiworks.com"))
+    assert_selector expand_button
+  end
+
+  def test_component_library_mode
+    render_inline(InlineWidgetComponent.new(widget: @widget, library_mode: true, expand_url: "https://moxiworks.com"))
+    assert_selector "div.#{@widget[:component]}.pointer-events-none[inert]"
+    assert_no_selector "a"
+    assert_no_selector "button"
+  end
+end

--- a/test/components/list_trac/list_trac_component_test.rb
+++ b/test/components/list_trac/list_trac_component_test.rb
@@ -17,15 +17,6 @@ class ListTrac::ListTracComponentTest < ViewComponent::TestCase
 
   # Inline component tests
 
-  def test_inline_component_renders_name
-    with_inline_component do
-      assert_includes(
-        rendered.to_html,
-        @widget.name
-      )
-    end
-  end
-
   def test_inline_component_renders_listing_table
     with_inline_component do
       with_listings do
@@ -48,74 +39,7 @@ class ListTrac::ListTracComponentTest < ViewComponent::TestCase
     end
   end
 
-  def test_inline_component_renders_logo
-    with_inline_component do
-      assert_includes(
-        rendered.css("img#logo").to_html,
-        "logo.png"
-      )
-      assert_includes(
-        rendered.css("img#logo").to_html,
-        "alt=\"#{@widget.partner}\""
-      )
-    end
-  end
-
-  def test_inline_component_renders_error
-    with_inline_component do
-      instance_variable_set(:@error, "unknown error") do
-        assert_includes(
-          rendered.to_html,
-          "working on fixing things"
-        )
-      end
-    end
-  end
-
-  def test_component_renders_error_with_api
-    instance_variable_set(:@error, "unknown error") do
-      instance_variable_set(:@error_with_api, true) do
-        assert_includes(
-          rendered.to_html,
-          "trouble connecting to ListTrac"
-        )
-      end
-    end
-  end
-
-  # Expanded component tests
-  # The table is generated with JavaScript, so we can't test it here
-
-  def test_expanded_component_renders_name_in_header
-    with_expanded_component do
-      assert_includes(
-        rendered.css("[slot='header-left']").to_html,
-        @widget.name
-      )
-    end
-  end
-
-  def test_expanded_component_renders_logo_link
-    with_expanded_component do
-      assert_includes(
-        rendered.css("[slot='footer-left'] a").to_html,
-        @widget.logo_link_url
-      )
-    end
-  end
-
-  def test_expanded_component_renders_logo
-    with_expanded_component do
-      assert_includes(
-        rendered.css("[slot='footer-left'] img").to_html,
-        "logo.png"
-      )
-      assert_includes(
-        rendered.css("[slot='footer-left'] img").to_html,
-        "alt=\"#{@widget.partner}\""
-      )
-    end
-  end
+  # The expanded component table is generated with JavaScript, so we can't test it here
 
   private
 
@@ -125,12 +49,6 @@ class ListTrac::ListTracComponentTest < ViewComponent::TestCase
 
   def with_inline_component
     with_request_url "/component/list_trac/12345" do
-      yield
-    end
-  end
-
-  def with_expanded_component
-    with_request_url "/component/list_trac/expanded/12345" do
       yield
     end
   end

--- a/test/components/tips/tips_component_test.rb
+++ b/test/components/tips/tips_component_test.rb
@@ -9,13 +9,6 @@ class Tips::TipsComponentTest < ViewComponent::TestCase
     @error = nil
   end
 
-  def test_component_renders_name
-    assert_includes(
-      rendered.css("#heading").to_html,
-      @widget.name
-    )
-  end
-
   def test_component_renders_tip
     with_tips_params do
       assert_includes(
@@ -45,17 +38,6 @@ class Tips::TipsComponentTest < ViewComponent::TestCase
         "--tip-bg-#{my_tip[:bg]}"
       )
     end
-  end
-
-  def test_component_renders_logo
-    assert_includes(
-      rendered.css("img#logo").to_html,
-      "logo.png"
-    )
-    assert_includes(
-      rendered.css("img#logo").to_html,
-      "alt=\"#{@widget.partner}\""
-    )
   end
 
   private


### PR DESCRIPTION
## Description

I've added component tests for the `inline_widget_component` and `expanded_widget_component`, and I've removed the redundant tests from the test files for `list_trac`, `hurdlr`, and `tips`.