### PR TITLE
OT-184 - Fix tip overflow/scrolling

### DIFF
--- a/app/assets/stylesheets/tips/style.css
+++ b/app/assets/stylesheets/tips/style.css
@@ -24,3 +24,14 @@
 .tips .tip-container {
   background-color: rgba(255, 255, 255, 0.95);
 }
+
+.tips .tip-container p {
+  --line-clamp: 7;
+  display: -webkit-box;
+  -webkit-line-clamp: var(--line-clamp);
+  -webkit-box-orient: vertical;
+}
+
+.tips .tip-container mx-button:not(.hidden) + p {
+  --line-clamp: 5;
+}

--- a/app/components/tips/tips_component.html.erb
+++ b/app/components/tips/tips_component.html.erb
@@ -2,15 +2,15 @@
 
 <%= render(InlineWidgetComponent.new(widget: @widget, library_mode: @library_mode)) do %>
   <div class="flex flex-1 py-12 px-16 tip-bg" style="--tip-bg: var(--tip-bg-<%= @bg %>)">
-    <div data-tip-id="<%= @id %>" class="tip-container w-full flex-1 flex flex-col items-center justify-center p-12 rounded-xl <%= @library_mode ? "pointer-events-none" : "" %>">
-      <p class="text-4 my-0 mb-8 text-center" style="overflow-wrap: anywhere">
-        <%= @tip %>
-      </p>
+    <div data-tip-id="<%= @id %>" class="tip-container w-full flex-1 flex flex-col-reverse items-center justify-center p-12 rounded-xl <%= @library_mode ? "pointer-events-none" : "" %>">
       <% if @cta_label.present? %>
         <mx-button btn-type="text" href="<%= @cta_url %>" class="max-w-full" target="_blank">
           <%= @cta_label %>
         </mx-button>
       <% end %>
+      <p class="text-4 my-0 mb-8 text-center overflow-hidden" style="overflow-wrap: anywhere">
+        <%= @tip %>
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
## Description

This adds line clamping to the tip shown in the `tips` widget, so users can clearly see that their tip is too long when previewing.  Although we have a reasonable character limit in place, real-world tips can still potentially end up with 8 or more lines if there are a lot of wide characters in use.

When the tip includes a CTA button, the widget only can fit 5 lines of text, but when there is no CTA button, it can show 7 lines.  Since there is no CSS selector for "previous sibling", I had to swap the order of the `mx-button` and `p` elements, so I could use the "next sibling" selector (`+`).  And in order to then display them in the same order as before, I changed their parent's `.flex-col` class to `.flex-col-reverse` (`flex-direction: column-reverse`).

### Before: 👎

![image](https://github.com/moxiworks/widget-factory/assets/3342530/5049010a-40cf-452c-8535-62f9bd069d39)
![image](https://github.com/moxiworks/widget-factory/assets/3342530/557c6be1-c290-4d52-bb4b-a0a2fb137e97)

### After: 👍

![image](https://github.com/moxiworks/widget-factory/assets/3342530/8122dab8-83fe-4444-8c8f-6fb9564eaf1b)
![image](https://github.com/moxiworks/widget-factory/assets/3342530/d7dc28f1-14b3-47fd-bfc5-9c5525b01536)


## JIRA Link
https://moxiworks.atlassian.net/browse/OT-184

## Validation Steps
Verify that tips with 8 or more lines are truncated to either 5 lines (if a CTA button is shown) or 7 lines (if there is no button).
