### PR TITLE
Fix standardrb crashes; Fix linting errors

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -8,3 +8,7 @@ ignore: # default: []
   - 'vendor/**/*'
   - '**/lograge.rb'
   - '**/log_initializer.rb'
+  - 'tmp/**/*'
+  - 'bin/**/*'
+  - '.git/**/*'
+  - 'node_modules/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :test do
   gem "minitest-junit"
 end
 
-gem 'knapsack', group: [:development, :test]
+gem "knapsack", group: [:development, :test]
 
 gem "webmock", "~> 3.18"
 

--- a/app/assets/stylesheets/rismedia/style.css
+++ b/app/assets/stylesheets/rismedia/style.css
@@ -1,11 +1,11 @@
-.rismedia [role="tab"][aria-selected="true"] {
+.rismedia [role='tab'][aria-selected='true'] {
   background-color: var(--primary);
 }
-.rismedia [role="tab"]:hover {
+.rismedia [role='tab']:hover {
   background-color: #7b4db7;
 }
-.rismedia [role="tab"][aria-selected="true"] > span,
-.rismedia [role="tab"]:hover > span {
+.rismedia [role='tab'][aria-selected='true'] > span,
+.rismedia [role='tab']:hover > span {
   color: var(--mds-text-primary-inverted);
 }
 .rismedia article a {

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -25,7 +25,9 @@ class ApplicationComponent < ViewComponent::Base
       session.dig(:current_user, :uuid),
       session.dig(:current_user, :company_uuid),
       session.dig(:current_user, :board_uuid),
-      session.dig(:current_user, :office_uuid)  
-    ) rescue nil
+      session.dig(:current_user, :office_uuid)
+    )
+  rescue
+    nil
   end
 end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -12,6 +12,6 @@ class Api::EventsController < ApplicationController
       session.dig(:current_user, :board_uuid),
       session.dig(:current_user, :office_uuid)
     )
-    render json: { success: true }
+    render json: {success: true}
   end
 end

--- a/app/controllers/api/user_widgets_controller.rb
+++ b/app/controllers/api/user_widgets_controller.rb
@@ -9,7 +9,7 @@ class Api::UserWidgetsController < ApplicationController
       user_widget.row_order_position = index + 1
       user_widget.save
     end
-    render json: { status: :ok }
+    render json: {status: :ok}
   end
 
   # DELETE /api/user_widgets/:id
@@ -18,9 +18,9 @@ class Api::UserWidgetsController < ApplicationController
     user_widget = UserWidget.find_or_initialize_by(widget_id: params[:id], user_uuid: user_uuid)
     user_widget.removed = true
     if user_widget.save
-      render json: { status: :ok }
+      render json: {status: :ok}
     else
-      render json: { status: :error }
+      render json: {status: :error}
     end
   end
 
@@ -30,9 +30,9 @@ class Api::UserWidgetsController < ApplicationController
     user_widget = UserWidget.find_or_initialize_by(widget_id: params[:id] || params[:widget_id], user_uuid: user_uuid)
     user_widget.removed = false
     if user_widget.save
-      render json: { status: :ok }
+      render json: {status: :ok}
     else
-      render json: { status: :error }
+      render json: {status: :error}
     end
   end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -14,7 +14,7 @@ class Session
       board_external_id: user[:board][:board_external_id],
       board_mls_id: user[:board][:mls_id],
       board_uuid: user[:board][:board_uuid],
-      office_uuid: user[:office][:office_uuid],
+      office_uuid: user[:office][:office_uuid]
     }
 
     session[:current_user] = h

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module WidgetFactory
       config.service_url = {
         auth: ENV["auth_service_url"] || "#{config.base_service}/service/v1/auth",
         profile_v2: ENV["profile_service_v2_url"] || "#{config.base_service}/service/profile/v2",
-        profile_v3: ENV["profile_service_v2_url"] || "#{config.base_service}/service/profile/v3",
+        profile_v3: ENV["profile_service_v3_url"] || "#{config.base_service}/service/profile/v3"
       }
 
       config.active_job.queue_adapter = :sidekiq

--- a/config/initializers/vendor_access.rb
+++ b/config/initializers/vendor_access.rb
@@ -1,5 +1,5 @@
-VendorApiAccess = if ENV['VENDOR_API_ACCESS'].present?
-                    YAML.load(ENV.fetch('VENDOR_API_ACCESS'))
-                  else
-                    YAML.load_file(Rails.root.join('config', 'vendor_api_data.yml'))
-                  end
+VendorApiAccess = if ENV["VENDOR_API_ACCESS"].present? # rubocop:disable Naming/ConstantName
+  YAML.safe_load(ENV.fetch("VENDOR_API_ACCESS"))
+else
+  YAML.load_file(Rails.root.join("config", "vendor_api_data.yml"))
+end

--- a/ops/dev/.irbrc
+++ b/ops/dev/.irbrc
@@ -1,8 +1,7 @@
 # Tab completion
-require 'irb/completion'
+require "irb/completion"
 # Save irb sessions to history file
-require 'irb/ext/save-history'
-
+require "irb/ext/save-history"
 
 IRB.conf[:SAVE_HISTORY] = 2000
-IRB.conf[:HISTORY_FILE] = '/app/log/.irb-history'
+IRB.conf[:HISTORY_FILE] = "/app/log/.irb-history"

--- a/test/controllers/api/user_widgets_controller_test.rb
+++ b/test/controllers/api/user_widgets_controller_test.rb
@@ -10,28 +10,28 @@ class Api::UserWidgetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should set widget order" do
-    patch api_user_widgets_path, params: { widget_ids: @widget_ids }, headers: { "Authorization": @jwt }
+    patch api_user_widgets_path, params: {widget_ids: @widget_ids}, headers: {Authorization: @jwt}
     assert_response :success
     assert_equal @widget_ids, UserWidget.where(user_uuid: @user_uuid).pluck(:widget_id)
-    patch api_user_widgets_path, params: { widget_ids: @widget_ids.reverse }, headers: { "Authorization": @jwt }
+    patch api_user_widgets_path, params: {widget_ids: @widget_ids.reverse}, headers: {Authorization: @jwt}
     assert_response :success
     assert_equal @widget_ids.reverse, UserWidget.where(user_uuid: @user_uuid).pluck(:widget_id)
   end
 
   test "should remove user widget" do
-    delete api_destroy_user_widget_path(widgets(:one).id), headers: { "Authorization": @jwt }
+    delete api_destroy_user_widget_path(widgets(:one).id), headers: {Authorization: @jwt}
     assert_response :success
     assert user_widgets(:one).removed
   end
 
   test "should remove widget that was not previously removed/ordered" do
     assert_difference "UserWidget.count", 1 do
-      delete api_destroy_user_widget_path(widgets(:three).id), headers: { "Authorization": @jwt }
+      delete api_destroy_user_widget_path(widgets(:three).id), headers: {Authorization: @jwt}
     end
   end
 
   test "should restore user widget" do
-    post api_restore_user_widget_path(widgets(:two).id), headers: { "Authorization": @jwt }
+    post api_restore_user_widget_path(widgets(:two).id), headers: {Authorization: @jwt}
     assert_response :success
     refute user_widgets(:two).removed
   end

--- a/test/controllers/api/widgets_controller_test.rb
+++ b/test/controllers/api/widgets_controller_test.rb
@@ -10,7 +10,7 @@ class Api::WidgetsControllerTest < ActionController::TestCase
 
   test "should get single widget" do
     widget = widgets(:one)
-    get :show, params: { id: widget.id }
+    get :show, params: {id: widget.id}
     assert_response :success
     response_body = JSON.parse(response.body)
     assert_equal widget.id, response_body["id"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require "webmock/minitest"
 require_relative "../config/environment"
 require "rails/test_help"
 
-require 'knapsack'
+require "knapsack"
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
@@ -16,7 +16,7 @@ class ActiveSupport::TestCase
 
   setup do
     WebMock.allow_net_connect!
-  end  
+  end
 end
 
 knapsack_adapter = Knapsack::Adapters::MinitestAdapter.bind


### PR DESCRIPTION
## Description

I haven't been able to run all the lefthook pre-push checks for a while because standardrb kept crashing with a weird parser error.  I finally figured out that it was checking a lot of files that should have been ignored, but our `.standard.yml` was overriding the default ignores, so it was missing some of the defaults.

- Added a few more locations to the standardrb `ignores`
- Fixed all the linting errors.  I added an explicit ignore to one "offense" related to a variable name because I didn't want to risk breaking anything.
