### PR TITLE
Fix event_data in sidekiq job

### DIFF
--- a/app/sidekiq/event_logger_job.rb
+++ b/app/sidekiq/event_logger_job.rb
@@ -2,6 +2,7 @@ class EventLoggerJob
   include Sidekiq::Job
 
   def perform(event_type, component, event_data, agent_uuid, company_uuid, board_uuid, office_uuid)
+    event_data = JSON.parse(event_data) || {}
     event_data[:component] = component
     event_data[:board_uuid] = board_uuid
     event_data[:office_uuid] = office_uuid


### PR DESCRIPTION
## Description

I just noticed a bunch of failed jobs in my local sidekiq dashboard, and it's because I wasn't parsing the `event_data` JSON in the sidekiq before trying to add the `component`, `board_uuid`, and `office_uuid` properties to that object.  Not sure how I missed this until now, but I'm glad I caught it.