### PR TITLE
Add support for datadog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "actionpack-action_caching"
 gem "jwt"
 
 gem "ranked-model"
+gem "ddtrace"
+gem "dogstatsd-ruby", require: "datadog/statsd"
 
 gem "aws-sdk-s3", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,9 +151,16 @@ GEM
       rexml
     crass (1.0.6)
     dalli (3.2.3)
+    ddtrace (1.12.1)
+      debase-ruby_core_source (= 3.2.1)
+      libdatadog (~> 2.0.0.1.0)
+      libddwaf (~> 1.9.0.0.0)
+      msgpack
+    debase-ruby_core_source (3.2.1)
     debug (1.6.3)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
+    dogstatsd-ruby (5.5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erb_lint (0.3.1)
@@ -164,6 +171,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.11.0)
+    ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
@@ -188,6 +196,11 @@ GEM
     knapsack (4.0.0)
       rake
     lefthook (1.2.2)
+    libdatadog (2.0.0.1.0)
+    libddwaf (1.9.0.0.1)
+      ffi (~> 1.0)
+    libddwaf (1.9.0.0.1-x86_64-darwin)
+      ffi (~> 1.0)
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -374,7 +387,9 @@ DEPENDENCIES
   bootsnap
   capybara
   dalli (~> 3.2.0)
+  ddtrace
   debug
+  dogstatsd-ruby
   erb_lint
   importmap-rails
   jbuilder

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,25 @@
+# Configures datadog for APM tracing
+# See: https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md
+service_name = 'widget-factory'
+if !Rails.env.test?
+  Datadog.configure do |c|
+    dd_enabled = ENV['DD_APM_ENABLED'].to_s == 'true'
+    c.tracing.enabled = dd_enabled
+    if dd_enabled
+      c.env = Rails.env
+      c.service = service_name
+      c.version = ENV['BUILD_VERSION'] || ENV['GIT_TAG'] || `git describe --tags`.chomp
+      c.agent.host = ENV['DD_AGENT_HOST'] || 'localhost'
+      c.agent.port = ENV['DD_TRACE_AGENT_PORT'] || '8126'
+      c.tracing.instrument :rack,  { request_queuing: true, service_name: "#{service_name}-rack"  }
+      c.tracing.instrument :rails, {service_name: "#{service_name}-rails" }
+      c.tracing.instrument :redis, {service_name: "#{service_name}-redis" }
+      c.tracing.instrument :active_record , {service_name: "#{service_name}-postgres" }
+      c.tracing.instrument :dalli, {service_name: "#{service_name}-memcached" }
+      c.tracing.instrument :pg , {service_name: "#{service_name}-pg" }
+      c.tracing.instrument :http, {service_name: "#{service_name}-http" }
+      c.tracing.instrument :resque,  {service_name: "#{service_name}-resque" }
+      c.tracing.instrument :rest_client, {service_name: "#{service_name}-rest" }
+    end
+  end
+end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -9,8 +9,8 @@ if !Rails.env.test?
       c.env = Rails.env
       c.service = service_name
       c.version = ENV['BUILD_VERSION'] || ENV['GIT_TAG'] || `git describe --tags`.chomp
-      c.agent.host = ENV['DD_AGENT_HOST'] || 'localhost'
-      c.agent.port = ENV['DD_TRACE_AGENT_PORT'] || '8126'
+      c.agent.host = ENV['DD_AGENT_SERVICE_HOST'] || ENV['DD_AGENT_HOST'] || 'localhost'
+      c.agent.port = ENV['DD_AGENT_SERVICE_PORT'] || ENV['DD_TRACE_AGENT_PORT'] || '8126'
       c.tracing.instrument :rack,  { request_queuing: true, service_name: "#{service_name}-rack"  }
       c.tracing.instrument :rails, {service_name: "#{service_name}-rails" }
       c.tracing.instrument :redis, {service_name: "#{service_name}-redis" }


### PR DESCRIPTION
## Description

_Add support for Datadog for new Widget Factory service_

## JIRA Link
https://moxiworks.atlassian.net/browse/ENG-165830

## Validation Steps
- Ensure widget factory still works
- See if you get cool new stats in datadog (ActivePipe side)