### PR TITLE
OT-207 & OT-208 - Fix widget panel scrollbars and flaky modals

### DIFF
--- a/app/assets/javascripts/expanded_widget_component.js
+++ b/app/assets/javascripts/expanded_widget_component.js
@@ -7,23 +7,17 @@ window.WidgetFactory.setUpModal = function (component) {
   addCloseHandlers();
 };
 
-/** Open the modal when the mx-modal element is ready */
+/** Open the modal and toggle parent loading spinner */
 function openModalWhenReady(component) {
   const modal = document.querySelector('mx-modal');
-  const observer = new MutationObserver(() => {
-    requestAnimationFrame(() => {
-      modal.isOpen = true;
-      window.parent.postMessage(
-        {
-          type: 'SET_LOADING',
-          payload: { component, isLoading: false },
-        },
-        '*'
-      );
-    });
-    observer.disconnect();
-  });
-  observer.observe(modal, { subtree: true, childList: true });
+  modal.isOpen = true;
+  window.parent.postMessage(
+    {
+      type: 'SET_LOADING',
+      payload: { component, isLoading: false },
+    },
+    '*'
+  );
 }
 
 /** Log an event when the logo is clicked */

--- a/app/assets/javascripts/inline_widget_component.js
+++ b/app/assets/javascripts/inline_widget_component.js
@@ -5,7 +5,7 @@ window.WidgetFactory.addMessageHandler = function (component) {
   window.addEventListener('message', e => {
     if (e.data.type === 'UPDATE_PREVIEW')
       updatePreview(component, e.data.payload);
-    if (e.data.type === 'SET_LOADING')
+    if (e.data.type === 'SET_LOADING' && e.data.payload.component === component)
       window.WidgetFactory.setLoading(component, e.data.payload.isLoading);
   });
 };

--- a/app/assets/javascripts/widget_panel_component_expanded.js
+++ b/app/assets/javascripts/widget_panel_component_expanded.js
@@ -8,20 +8,14 @@ const sendCloseMessage = async () => {
   window.parent.postMessage({ type: 'CLOSE_EXPANDED', payload: {} }, '*');
 };
 const modal = root.querySelector('mx-modal');
-const observer = new MutationObserver(mutations => {
-  requestAnimationFrame(() => {
-    modal.isOpen = true;
-    window.parent.postMessage(
-      {
-        type: 'SET_LOADING',
-        payload: { component: 'widget_panel', isLoading: false },
-      },
-      '*'
-    );
-  });
-  observer.disconnect();
-});
-observer.observe(root, { subtree: true, childList: true });
+modal.isOpen = true;
+window.parent.postMessage(
+  {
+    type: 'SET_LOADING',
+    payload: { component: 'widget_panel', isLoading: false },
+  },
+  '*'
+);
 modal.addEventListener('mxClose', sendCloseMessage);
 /* The close-on-escape behavior provided by mx-modal does not work in an iframe. */
 document.addEventListener('keydown', e => {

--- a/app/assets/javascripts/widget_panel_component_expanded.js
+++ b/app/assets/javascripts/widget_panel_component_expanded.js
@@ -88,14 +88,18 @@ removeButtons.forEach(button => {
 });
 
 function logEvent(eventType, eventData, component = 'widget_panel') {
-  _fetch(`/api/events/?session_id=${window.WidgetFactory.SESSION_ID}`, {
-    method: 'POST',
-    body: JSON.stringify({
-      event_type: eventType,
-      event_data: eventData,
-      component,
-    }),
-  });
+  _fetch(
+    `/api/events/?session_id=${window.WidgetFactory.SESSION_ID}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        event_type: eventType,
+        event_data: eventData,
+        component,
+      }),
+    },
+    true
+  );
 }
 
 function restoreUserWidget(widgetId, component) {
@@ -116,7 +120,7 @@ function destroyUserWidget(widgetId, component) {
     }
   );
 }
-async function _fetch(url, options) {
+async function _fetch(url, options, silent = false) {
   options = { ...options, headers: { 'Content-Type': 'application/json' } };
   const promise = fetch(url, options);
   activeRequests.push(promise);
@@ -124,7 +128,9 @@ async function _fetch(url, options) {
   activeRequests = activeRequests.filter(p => p !== promise);
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
-  } else {
+    return;
+  }
+  if (!silent) {
     window.parent.postMessage(
       {
         type: 'SET_LOADING',

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -30,6 +30,7 @@
 }
 body {
   margin: 0;
+  overflow: hidden;
 }
 .inline-widget {
   min-height: 18.5rem; /* 296px */

--- a/config/initializers/mds_version.rb
+++ b/config/initializers/mds_version.rb
@@ -1,1 +1,1 @@
-Rails.application.config.mds_version = "0.1.51"
+Rails.application.config.mds_version = "0.1.61"


### PR DESCRIPTION
## Description

- Set `overflow: hidden` on the body of the default layout to prevent a scrollbar in the My Widgets panel. [OT-207](https://moxiworks.atlassian.net/browse/OT-207)
- Updated MDS to v0.1.61, which fixes an issue with modals not opening when `isOpen` is set to `true` before the component has finished loading.  I was then able to remove the hacky mutation observers that were attempting to work around this issue. [OT-208](https://moxiworks.atlassian.net/browse/OT-208) https://github.com/moxiworks/mds/pull/240
- Fixed an issue with loading spinners appearing on all widgets while the Widget Library modal is opening.
- Updated the Widget Library to log events silently (without triggering a loading spinner over the My Widgets panel).

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-207
https://moxiworks.atlassian.net/browse/OT-208

## Validation Steps
- Verify that widgets expand correctly.
- Verify that the Widget Library modal opens correctly.
- Verify that a scrollbar never appears alongside the My Widgets panel.
- Verify that there are not excessive loading spinners when opening the Widget Library modal.


[OT-207]: https://moxiworks.atlassian.net/browse/OT-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OT-208]: https://moxiworks.atlassian.net/browse/OT-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ