### PR TITLE
OT-202 - External Widget Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,23 @@ To add a default logo for a new widget, place the file in a subdirectory of `/as
 Widget.find_by(component: "todo_list").logo.attach(io: File.open(Rails.root.join("app/assets/images/todo_list/logo.png")), filename: "logo.png")
 ```
 
+## External Widgets
+
+External widgets are hosted by a third party. The `external_widget` component simply renders the `Widget.external_url` in an iframe.
+
+A widget in the `widgets` table is considered "external" if:
+
+- the `external_url` column is populated, _and_
+- the `component` column value begins with `external` (e.g. `external_1`). TODO: Once these are created via the developer portal, we will need to come up with a convention and logic for generating unique component names.
+
+The external URL may make use of the following variables:
+
+- `{FULL_NAME}`: The current user's full name
+- `{MLS_NUMBER}`: The current user's MLS number
+- `{NRDS_NUMBER}`: The current user's NRDS number
+
+These variables will be replaced with the user's information when the widget is rendered. For example, if the `external_url` is `https://example.com?name={FULL_NAME}`, and the user's full name is "John Doe", the iframe will render `https://example.com?name=John%20Doe`.
+
 ## API Endpoints
 
 As [mentioned previously](#authentication), all API requests should provide a `session_id` query parameter for authentication purposes. This parameter is not required for the `/api/jwt` endpoint.

--- a/app/components/external_widget/external_widget_component.html.erb
+++ b/app/components/external_widget/external_widget_component.html.erb
@@ -1,0 +1,3 @@
+<%= render(InlineWidgetComponent.new(widget: @widget, library_mode: @library_mode)) do %>
+  <iframe src="<%= @iframe_url %>" class="flex-1" style="width: 18.375rem"></iframe>
+<% end %>

--- a/app/components/external_widget/external_widget_component.rb
+++ b/app/components/external_widget/external_widget_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ExternalWidget::ExternalWidgetComponent < ApplicationComponent
+  include Components::ExternalWidgetHelper
+
+  def before_render
+    super
+    return if @error.present?
+    @iframe_url = populate_url_variables(@widget.external_url)
+  end
+end

--- a/app/controllers/component_controller.rb
+++ b/app/controllers/component_controller.rb
@@ -1,10 +1,11 @@
 class ComponentController < ApplicationController
   def name
     # Looks for namespaced component first.
+    c = params[:name].start_with?("external") ? "external_widget" : params[:name]
     obj = begin
-      Object.const_get("#{params[:name].camelize}::#{params[:name].camelize}Component").new
+      Object.const_get("#{c.camelize}::#{c.camelize}Component").new
     rescue
-      Object.const_get("#{params[:name].camelize}Component").new
+      Object.const_get("#{c.camelize}Component").new
     end
 
     render(obj)

--- a/app/helpers/components/external_widget_helper.rb
+++ b/app/helpers/components/external_widget_helper.rb
@@ -1,0 +1,19 @@
+module Components::ExternalWidgetHelper
+  def populate_url_variables(url)
+    return url unless url.include?("{")
+    url_variables.each do |key, value|
+      url.gsub!(Regexp.new("{#{key}}", Regexp::IGNORECASE), URI.encode_www_form_component(value.to_s))
+    end
+    url
+  end
+
+  private
+
+  def url_variables
+    {
+      mls_number: session.dig(:current_user, :mls_number),
+      nrds_number: session.dig(:current_user, :nrds_number),
+      full_name: session.dig(:current_user, :full_name)
+    }
+  end
+end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -24,7 +24,8 @@ class Widget < ApplicationRecord
   end
 
   def view_component
-    Object.const_get("#{component.camelize}::#{component.camelize}Component")
+    c = component.start_with?("external") ? "external_widget" : component
+    Object.const_get("#{c.camelize}::#{c.camelize}Component")
   rescue NameError
     nil
   end

--- a/db/migrate/20230601203528_add_external_url_to_widgets.rb
+++ b/db/migrate/20230601203528_add_external_url_to_widgets.rb
@@ -1,0 +1,5 @@
+class AddExternalUrlToWidgets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :widgets, :external_url, :string
+  end
+end


### PR DESCRIPTION
## Description

This PR is for the initial implementation of the External Widget component that renders an external URL in an iframe.  It also replaces variables such as `{MLS_NUMBER}` in that external URL with values pertaining to the user.

![image](https://github.com/moxiworks/widget-factory/assets/3342530/6c7638bc-4a3c-410c-ad8a-22656d4789f9)



As mentioned in the README, widgets are expected to have a unique `component` name, but all external widgets will use the same `external_widget` component for rendering, so external widgets will need to use something like `external_1`.  If I were starting this project over, I would avoid this "magic" prefix, but I think it's the least dangerous and least confusing way to patch this in now.

I'm targeting a new `ot-181-dev-portal` branch (based on `main`) with this PR since we will be releasing the RISMedia widget from `main` soon, and introducing a `release` or `release-candidate` branch in the meantime would be confusing.  We can merge this dev portal branch into a new release branch at some point in the future if we want.

## JIRA Link

https://moxiworks.atlassian.net/browse/OT-202
