### PR TITLE
OT-212 - Do not render <img> in widget footer if no logo is present

### DIFF
--- a/app/components/inline_widget_component.html.erb
+++ b/app/components/inline_widget_component.html.erb
@@ -16,18 +16,21 @@
   </div>
 
   <% wrap_logo_with_link = !@library_mode && @widget.logo_link_url.present? %>
-  <footer class="flex items-center justify-between min-h-48 bg-white border-t px-16">
-    <% if wrap_logo_with_link %>
-      <a href="<%= @widget.logo_link_url %>" target="_blank">
-    <% end %>
-    <img
-      id="logo"
-      src="<%= @widget.logo_url %>"
-      alt="<%= @widget.partner %>"
-      style="max-height: 1.875rem;"
-    />
-    <% if wrap_logo_with_link %>
-      </a>
+  <% justify_class = @widget.logo_url.present? ? "justify-between" : "justify-end" %>
+  <footer class="flex items-center <%= justify_class %> min-h-48 bg-white border-t px-16">
+    <% if @widget.logo_url.present? %>
+      <% if wrap_logo_with_link %>
+        <a href="<%= @widget.logo_link_url %>" target="_blank">
+      <% end %>
+      <img
+        id="logo"
+        src="<%= @widget.logo_url %>"
+        alt="<%= @widget.partner %>"
+        style="max-height: 1.875rem;"
+      />
+      <% if wrap_logo_with_link %>
+        </a>
+      <% end %>
     <% end %>
     <div class="actions flex items-center space-x-8">
       <% unless @library_mode %>


### PR DESCRIPTION
## Description

This updates the `inline_widget` component to not try to render the logo `<img>` if there is no logo attached to the widget.

### Before

![image](https://github.com/moxiworks/widget-factory/assets/3342530/6a610920-491b-4185-9231-eae958fdeec5)

### After

![image](https://github.com/moxiworks/widget-factory/assets/3342530/e51e5fdb-a296-4d8e-a654-1c859ef6bcad)


## JIRA Link
https://moxiworks.atlassian.net/browse/OT-212

## Validation Steps
Remove the logo from a widget, and save the widget.  The widget should not show a broken image in the My Widgets panel.

