### PR TITLE
OT-203 - Update Widget model and API controller for dev portal submission

### DIFF
--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -13,6 +13,19 @@ class Api::WidgetsController < ApplicationController
     render json: @widget
   end
 
+  # POST /api/widgets
+  def create
+    @widget = Widget.new(widget_params)
+    if params[:widget][:logo_base64].present?
+      @widget.logo = decode_logo
+    end
+    if @widget.save
+      render json: @widget, status: :created
+    else
+      render json: @widget.errors, status: :unprocessable_entity
+    end
+  end
+
   # PATCH/PUT /api/widgets/1
   def update
     @widget = Widget.find(params[:id])
@@ -41,6 +54,6 @@ class Api::WidgetsController < ApplicationController
   end
 
   def widget_params
-    params.require(:widget).permit(:name, :description, :status, :activation_date, :remove_logo, :updated_by)
+    params.require(:widget).permit(:name, :description, :status, :activation_date, :remove_logo, :updated_by, :partner, :logo_link_url, :external_url, :external_preview_url, :external_expanded_url, :submitted_by_uuid)
   end
 end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -65,7 +65,7 @@ class Widget < ApplicationRecord
   end
 
   def set_external_component
-    if component.blank? && external_url.present?
+    if component.blank?
       update_column(:component, "external_#{id}")
     end
   end

--- a/db/migrate/20230717154132_add_external_urls_to_widgets.rb
+++ b/db/migrate/20230717154132_add_external_urls_to_widgets.rb
@@ -1,0 +1,6 @@
+class AddExternalUrlsToWidgets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :widgets, :external_preview_url, :string # for library modal and admin form previews
+    add_column :widgets, :external_expanded_url, :string
+  end
+end

--- a/db/migrate/20230718132733_add_submitted_at_to_widgets.rb
+++ b/db/migrate/20230718132733_add_submitted_at_to_widgets.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtToWidgets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :widgets, :submitted_at, :datetime
+  end
+end

--- a/db/migrate/20230718180237_add_submitted_by_uuid.rb
+++ b/db/migrate/20230718180237_add_submitted_by_uuid.rb
@@ -1,0 +1,5 @@
+class AddSubmittedByUuid < ActiveRecord::Migration[7.0]
+  def change
+    add_column :widgets, :submitted_by_uuid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_09_184001) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_180237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_09_184001) do
     t.string "updated_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "external_url"
+    t.string "external_preview_url"
+    t.string "external_expanded_url"
+    t.datetime "submitted_at"
+    t.string "submitted_by_uuid"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/controllers/api/widgets_controller_test.rb
+++ b/test/controllers/api/widgets_controller_test.rb
@@ -39,4 +39,37 @@ class Api::WidgetsControllerTest < ActionController::TestCase
     assert_equal new_properties[:updated_by], response_body["updated_by"]
     assert_not_nil response_body["logo_url"]
   end
+
+  test "should create external widget" do
+    new_properties = {
+      name: "New Widget Name",
+      description: "New Widget Description",
+      status: "unsubmitted",
+      external_url: "https://www.example.com",
+      external_preview_url: "https://www.example.com",
+      external_expanded_url: "https://www.example.com",
+      submitted_by_uuid: "12345678-1234-1234-1234-123456789012",
+      partner: "Example Partner",
+      updated_by: "John Doe",
+      logo_link_url: "https://www.example.com",
+      logo_base64: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    }
+    post :create, params: {
+      widget: new_properties
+    }
+    assert_response :success
+    response_body = JSON.parse(response.body)
+    assert_equal new_properties[:name], response_body["name"]
+    assert_equal new_properties[:description], response_body["description"]
+    assert_equal new_properties[:status], response_body["status"]
+    assert_equal new_properties[:external_url], response_body["external_url"]
+    assert_equal new_properties[:external_preview_url], response_body["external_preview_url"]
+    assert_equal new_properties[:external_expanded_url], response_body["external_expanded_url"]
+    assert_equal new_properties[:submitted_by_uuid], response_body["submitted_by_uuid"]
+    assert_equal new_properties[:partner], response_body["partner"]
+    assert_equal new_properties[:updated_by], response_body["updated_by"]
+    assert_equal new_properties[:logo_link_url], response_body["logo_link_url"]
+    assert_equal "external_#{response_body["id"]}", response_body["component"]
+    assert_not_nil response_body["logo_url"]
+  end
 end

--- a/test/models/widget_test.rb
+++ b/test/models/widget_test.rb
@@ -74,8 +74,8 @@ class WidgetTest < ActiveSupport::TestCase
     assert_not_nil widget.submitted_at
   end
 
-  test "component should be set to external_{id} after create when external_url is present" do
-    widget = Widget.create(name: "My Widget", external_url: "https://www.example.com")
+  test "component should be set to external_{id} if not otherwise provided after create" do
+    widget = Widget.create(name: "My Widget")
     assert_equal "external_#{widget.id}", widget.component
   end
 end

--- a/test/models/widget_test.rb
+++ b/test/models/widget_test.rb
@@ -62,25 +62,20 @@ class WidgetTest < ActiveSupport::TestCase
     assert_equal "/rails/active_storage/blobs/redirect/#{widget.logo.blob.signed_id}/#{widget.logo.blob.filename}", widget.logo_url
   end
 
-  test "restore! should set status to draft and save the record" do
-    widget = Widget.new(name: "Test Widget", status: "ready")
-    widget.restore!
-    assert_equal "draft", widget.status
-    assert widget.persisted?
+  test "submitted_at should be set when status is submitted on create" do
+    widget = Widget.create(name: "My Widget", status: "submitted")
+    assert_not_nil widget.submitted_at
   end
 
-  test "activate! should set status to ready and save the record" do
-    widget = Widget.new(name: "Test Widget", status: "draft")
-    widget.activate!
-    assert_equal "ready", widget.status
-    assert widget.persisted?
+  test "submitted_at should be set when status is changed to submitted" do
+    widget = Widget.create(name: "My Widget", status: "unsubmitted")
+    assert_nil widget.submitted_at
+    widget.update(status: "submitted")
+    assert_not_nil widget.submitted_at
   end
 
-  test "deactivate! should set status to deactivated and activation date to nil, and save the record" do
-    widget = Widget.new(name: "Test Widget", status: "ready", activation_date: Time.zone.now)
-    widget.deactivate!
-    assert_equal "deactivated", widget.status
-    assert_nil widget.activation_date
-    assert widget.persisted?
+  test "component should be set to external_{id} after create when external_url is present" do
+    widget = Widget.create(name: "My Widget", external_url: "https://www.example.com")
+    assert_equal "external_#{widget.id}", widget.component
   end
 end


### PR DESCRIPTION
## Description

- Added migrations to add `external_preview_url`, `external_expanded_url`, `submitted_at`, and `submitted_by_uuid` columns to the `widgets` table.
- Added four new statuses to the `Widget` model:
  - **unsubmitted** - We already had a "draft" status, so that's why this is called "unsubmitted".
  - **submitted**
  - **rejected**
  - **review** - This will appear as "In Review" on the dev portal.
- Added ActiveRecord callbacks to automatically set the `submitted_at` date
- Added an ActiveRecord callback to automatically set the `component` value to `external_{id}` since it needs to be unique (see description here: https://github.com/moxiworks/widget-factory/pull/74)
- Added a `create` (POST) action to the `widgets_controller` and updated the permitted params accordingly
- Added test coverage for all of the above
- Removed a few unused methods from the `Widget` model.

These changes go hand-in-hand with https://github.com/moxiworks/nucleus/pull/816

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-203

## Validation Steps
Sending widget data like the data in the `widgets_controller_test` via POST to the `/api/widgets` endpoint should create an external widget in the database.
