### PR TITLE
OT-215 - Add WidgetSubmissionLogs and Widget.submission_notes

### DIFF
--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -9,8 +9,8 @@ class Api::WidgetsController < ApplicationController
 
   # GET /api/widgets/1
   def show
-    @widget = Widget.find(params[:id])
-    render json: @widget
+    @widget = Widget.includes(:widget_submission_logs).find(params[:id])
+    render json: @widget, include: :widget_submission_logs
   end
 
   # POST /api/widgets

--- a/app/models/widget_submission_log.rb
+++ b/app/models/widget_submission_log.rb
@@ -1,0 +1,3 @@
+class WidgetSubmissionLog < ApplicationRecord
+  belongs_to :widget
+end

--- a/db/migrate/20230719154857_create_widget_submission_logs.rb
+++ b/db/migrate/20230719154857_create_widget_submission_logs.rb
@@ -1,0 +1,15 @@
+class CreateWidgetSubmissionLogs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :widget_submission_logs do |t|
+      t.references :widget, null: false, foreign_key: true
+      t.string :status
+      t.text :notes
+      t.string :updated_by
+      t.string :logo_link_url
+      t.string :external_url
+      t.string :external_preview_url
+      t.string :external_expanded_url
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230719163802_add_submission_notes_to_widgets.rb
+++ b/db/migrate/20230719163802_add_submission_notes_to_widgets.rb
@@ -1,0 +1,5 @@
+class AddSubmissionNotesToWidgets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :widgets, :submission_notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_180237) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_19_163802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_180237) do
     t.index ["widget_id"], name: "index_user_widgets_on_widget_id"
   end
 
+  create_table "widget_submission_logs", force: :cascade do |t|
+    t.bigint "widget_id", null: false
+    t.string "status"
+    t.text "notes"
+    t.string "updated_by"
+    t.string "logo_link_url"
+    t.string "external_url"
+    t.string "external_preview_url"
+    t.string "external_expanded_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["widget_id"], name: "index_widget_submission_logs_on_widget_id"
+  end
+
   create_table "widgets", force: :cascade do |t|
     t.string "component"
     t.string "partner"
@@ -78,10 +92,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_180237) do
     t.string "external_expanded_url"
     t.datetime "submitted_at"
     t.string "submitted_by_uuid"
+    t.text "submission_notes"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "user_settings", "widgets"
   add_foreign_key "user_widgets", "widgets"
+  add_foreign_key "widget_submission_logs", "widgets"
 end

--- a/test/controllers/api/widgets_controller_test.rb
+++ b/test/controllers/api/widgets_controller_test.rb
@@ -14,6 +14,7 @@ class Api::WidgetsControllerTest < ActionController::TestCase
     assert_response :success
     response_body = JSON.parse(response.body)
     assert_equal widget.id, response_body["id"]
+    assert_equal 1, response_body["widget_submission_logs"].length
   end
 
   test "should update widget" do

--- a/test/fixtures/widget_submission_logs.yml
+++ b/test/fixtures/widget_submission_logs.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  widget: one
+  status: ready
+  notes: MyString
+  updated_by: MyString
+  logo_link_url: MyString
+  external_url: MyString
+  external_preview_url: MyString
+  external_expanded_url: MyString

--- a/test/fixtures/widgets.yml
+++ b/test/fixtures/widgets.yml
@@ -26,6 +26,6 @@ three:
   name: Widget Three
   description: MyString
   logo_link_url: MyString
-  status: draft
+  status: submitted
   activation_date: 2023-01-23 09:04:27
   updated_by: MyString


### PR DESCRIPTION
## Description

- Added a new model `WidgetSubmissionLog` for implementing the History section of the widget submission form.  I decided to include the various external URLs in these logs just to be safe even though the design does not currently show those changes on the page.
- Added `submission_notes` to the `Widget` model that will be used by both the submitter and approver.
- Updated the API's `widgets#show` (GET) action to include the widget submission log entries in the JSON response.
- Updated the `Widget` model with various Active Record callbacks:
  - Create a submission log entry when the widget's status changes (up until the widget has been approved).
  - Create a submission log entry when a widget is created and submitted at the same time.
  - Update the "submitted" log entry if the widget is revised after submission but before review has begun.
  - Clear the notes field once review has begun to make room for the approver's notes (since the submitter's notes are now persisted and displayed via the logs).
  - Clear the notes field once review has ended and the notes have been logged alongside the the Approved / Rejected status.
- Added test coverage for all of the above.
 
## JIRA Link
https://moxiworks.atlassian.net/browse/OT-215
