### PR TITLE
OT-201 - Use external_preview_url and/or demo values

### DIFF
--- a/app/components/external_widget/external_widget_component.rb
+++ b/app/components/external_widget/external_widget_component.rb
@@ -6,6 +6,9 @@ class ExternalWidget::ExternalWidgetComponent < ApplicationComponent
   def before_render
     super
     return if @error.present?
-    @iframe_url = populate_url_variables(@widget.external_url)
+    external_url = @library_mode ? @widget.external_preview_url : @widget.external_url
+    submission_preview = ["unsubmitted", "review", "rejected"].include?(@widget.status)
+    demo = @library_mode || submission_preview # use demo values for library or submission preview
+    @iframe_url = populate_url_variables(external_url, demo)
   end
 end

--- a/app/helpers/components/external_widget_helper.rb
+++ b/app/helpers/components/external_widget_helper.rb
@@ -1,7 +1,12 @@
 module Components::ExternalWidgetHelper
-  def populate_url_variables(url)
+  def populate_url_variables(url, demo = false)
     return url unless url.include?("{")
-    url_variables.each do |key, value|
+    variables = if demo
+      demo_values
+    else
+      Rails.env.test? ? test_values : session_values
+    end
+    variables.each do |key, value|
       url.gsub!(Regexp.new("{#{key}}", Regexp::IGNORECASE), URI.encode_www_form_component(value.to_s))
     end
     url
@@ -9,11 +14,27 @@ module Components::ExternalWidgetHelper
 
   private
 
-  def url_variables
+  def session_values
     {
       mls_number: session.dig(:current_user, :mls_number),
       nrds_number: session.dig(:current_user, :nrds_number),
       full_name: session.dig(:current_user, :full_name)
+    }
+  end
+
+  def demo_values
+    {
+      mls_number: "123456",
+      nrds_number: "123456789",
+      full_name: "Jane Doe"
+    }
+  end
+
+  def test_values
+    {
+      mls_number: "111111",
+      nrds_number: "111111111",
+      full_name: "Test User"
     }
   end
 end

--- a/test/components/external_widget/external_widget_component_test.rb
+++ b/test/components/external_widget/external_widget_component_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ExternalWidgetComponentTest < ViewComponent::TestCase
+  def setup
+    @widget = Widget.new(
+      name: "Test External Widget",
+      status: "unsubmitted",
+      component: "external_test",
+      partner: "MoxiWorks",
+      external_url: "https://example.com/{MLS_NUMBER}/{NRDS_NUMBER}/{FULL_NAME}",
+      external_preview_url: "https://example.com/preview/{MLS_NUMBER}/{NRDS_NUMBER}/{FULL_NAME}"
+    )
+    @widget.logo.attach(io: File.open(Rails.root.join("test", "fixtures", "files", "logo.png")), filename: "logo.png", content_type: "image/png")
+    @error = nil
+  end
+
+  def test_component_renders_submission_preview
+    render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget))
+    assert_selector("iframe[src='https://example.com/123456/123456789/Jane+Doe']")
+  end
+
+  def test_component_renders_library_preview
+    render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget, library_mode: true))
+    assert_selector("iframe[src='https://example.com/preview/123456/123456789/Jane+Doe']")
+  end
+
+  def test_component_renders_live_url
+    @widget.status = "ready"
+    render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget))
+    assert_selector("iframe[src='https://example.com/111111/111111111/Test+User']")
+  end
+end


### PR DESCRIPTION
## Description

- Added logic to use the `external_preview_url` instead of the `external_url` for the library modal (as well as the static preview in the nucleus admin)
- Added placeholder URL variable values for when the widget is in library mode or is being previewed in the dev portal (regardless of whether the iframe URL is the `external_url` or the `external_preview_url`).
- Added test coverage for the external widget component, which required adding `test_values` for the URL variables since the test environment in Rails does not have access to `session`.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-201
