### PR TITLE
OT-201 & OT-203 - Render external_expanded_url; API updates

### DIFF
--- a/app/components/external_widget/external_widget_component.html.erb
+++ b/app/components/external_widget/external_widget_component.html.erb
@@ -1,3 +1,9 @@
-<%= render(InlineWidgetComponent.new(widget: @widget, library_mode: @library_mode)) do %>
-  <iframe src="<%= @iframe_url %>" class="flex-1" style="width: 18.375rem"></iframe>
+<% if current_page?(component_named_expanded_path(@widget[:component])) %>
+  <%= render(ExpandedWidgetComponent.new(widget: @widget)) do %>
+    <iframe src="<%= @expanded_iframe_url %>" class="w-full h-full"></iframe>
+  <% end %>
+<% else %>
+  <%= render(InlineWidgetComponent.new(widget: @widget, expand_url: @expand_url, library_mode: @library_mode)) do %>
+    <iframe src="<%= @iframe_url %>" class="flex-1" style="width: 18.375rem"></iframe>
+  <% end %>
 <% end %>

--- a/app/components/external_widget/external_widget_component.rb
+++ b/app/components/external_widget/external_widget_component.rb
@@ -11,5 +11,9 @@ class ExternalWidget::ExternalWidgetComponent < ApplicationComponent
     submission_preview = ["unsubmitted", "review", "rejected"].include?(@widget.status)
     demo = @library_mode || submission_preview # use demo values for library or submission preview
     @iframe_url = populate_url_variables(external_url, demo)
+    if @widget.external_expanded_url.present?
+      @expand_url = component_named_expanded_path(@widget.component, params[:session_id])
+      @expanded_iframe_url = populate_url_variables(@widget.external_expanded_url)
+    end
   end
 end

--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -39,6 +39,17 @@ class Api::WidgetsController < ApplicationController
     end
   end
 
+  # DELETE /api/widgets/1
+  def destroy
+    @widget = Widget.find(params[:id])
+    if ["unsubmitted", "rejected", "submitted"].include?(@widget.status)
+      @widget.destroy
+      head :no_content
+    else
+      render json: { error: "Widget cannot be deleted" }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def decode_logo
@@ -54,6 +65,6 @@ class Api::WidgetsController < ApplicationController
   end
 
   def widget_params
-    params.require(:widget).permit(:name, :description, :status, :activation_date, :remove_logo, :updated_by, :partner, :logo_link_url, :external_url, :external_preview_url, :external_expanded_url, :submitted_by_uuid)
+    params.require(:widget).permit(:name, :description, :status, :activation_date, :remove_logo, :updated_by, :partner, :logo_link_url, :external_url, :external_preview_url, :external_expanded_url, :submitted_by_uuid, :submission_notes)
   end
 end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -81,7 +81,6 @@ class Widget < ApplicationRecord
   def add_submission_log
     # Do not create logs after the widget has been approved
     return if ["draft", "ready", "deactivated"].include?(status_was)
-    clear_notes if status == "review" # Clear submitter's notes once admin has started reviewing
     widget_submission_logs.create(
       status: status,
       notes: submission_notes,


### PR DESCRIPTION
## Description

This PR has a few changes that go along with https://github.com/moxiworks/nucleus/pull/820:
- Updated the `ExternalWidgetComponent` to render the `external_expanded_url`
- Added the `destroy` action to the widget API (for cancelling a submission from the dev portal)
- Added `submission_notes` to the API's permitted params
- Removed a line that previously cleared the `submission_notes` when an admin started reviewing a widget.  It's easier to just leave it on the widget record until the admin submits their approval or rejection.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-201
https://moxiworks.atlassian.net/browse/OT-203
