### PR TITLE
OT-200 - Implement dev widget preview 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The component will be viewable at the following URL:
 The `inline_widget` component is not a widget itself but provides common UI and functionality needed to render a widget "inline" (as shown in "My Widgets"). To use this component, your template should resemble the following:
 
 ```erb
-<%= render(InlineWidgetComponent.new(widget: @widget, library_mode: @library_mode, error: @error)) do %>
+<%= render(InlineWidgetComponent.new(widget: @widget, preview_mode: @preview_mode, error: @error)) do %>
   <!-- Your widget's inner HTML goes here -->
 <% end %>
 ```

--- a/app/assets/javascripts/dev_widget_preview_component_expanded.js
+++ b/app/assets/javascripts/dev_widget_preview_component_expanded.js
@@ -1,0 +1,14 @@
+/** Update the expanded preview's logo */
+/** The InlineWidgetComponent already has this behavior built-in. */
+window.addEventListener('message', e => {
+  if (e.data.type === 'UPDATE_PREVIEW') {
+    const { logo } = e.data.payload;
+    const logoEl = document.querySelector('#logo');
+    if (logo) {
+      logoEl.src = logo;
+      logoEl.classList.remove('hidden');
+    } else if (logo !== undefined) {
+      logoEl.classList.add('hidden');
+    }
+  }
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,6 +23,10 @@
   --mds-text-link: var(--primary);
   --mds-bg-gray: var(--mds-color-secondary-ultralight);
 }
+:root {
+  --inline-widget-width: 19.5rem;
+  --inline-widget-iframe-width: 18.375rem;
+}
 body {
   margin: 0;
   overflow: hidden;

--- a/app/assets/stylesheets/widget_panel/style.css
+++ b/app/assets/stylesheets/widget_panel/style.css
@@ -1,3 +1,6 @@
+:root {
+  --library-tile-width: 21.5rem; /* Also used by library_tile partial */
+}
 .icon-plus-circle {
   --svg: url("data:image/svg+xml;charset=UTF-8,%3csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3e%3cpath fill-rule='evenodd' clip-rule='evenodd' d='M3.75 12C3.75 7.44365 7.44365 3.75 12 3.75C16.5563 3.75 20.25 7.44365 20.25 12C20.25 16.5563 16.5563 20.25 12 20.25C7.44365 20.25 3.75 16.5563 3.75 12ZM12 2.25C6.61522 2.25 2.25 6.61522 2.25 12C2.25 17.3848 6.61522 21.75 12 21.75C17.3848 21.75 21.75 17.3848 21.75 12C21.75 6.61522 17.3848 2.25 12 2.25ZM12 7.5C12.4142 7.5 12.75 7.83579 12.75 8.25V11.25H15.75C16.1642 11.25 16.5 11.5858 16.5 12C16.5 12.4142 16.1642 12.75 15.75 12.75H12.75V15.75C12.75 16.1642 12.4142 16.5 12 16.5C11.5858 16.5 11.25 16.1642 11.25 15.75V12.75H8.25C7.83579 12.75 7.5 12.4142 7.5 12C7.5 11.5858 7.83579 11.25 8.25 11.25H11.25V8.25C11.25 7.83579 11.5858 7.5 12 7.5Z' fill='%23fff'/%3e%3c/svg%3e ");
 }
@@ -22,7 +25,7 @@
 }
 .widget-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, 19.5rem);
+  grid-template-columns: repeat(auto-fill, var(--inline-widget-width));
   align-items: stretch;
 }
 .widget-grid li > * {
@@ -30,7 +33,7 @@
 }
 .widget-library-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, 21.5rem);
+  grid-template-columns: repeat(auto-fill, var(--library-tile-width));
   gap: 1.5rem;
 }
 .keyboard-drag-button {

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,11 +1,11 @@
 class ApplicationComponent < ViewComponent::Base
-  def initialize(widget: nil, library_mode: false)
-    @library_mode = library_mode
+  def initialize(widget: nil, preview_mode: nil)
+    @preview_mode = preview_mode # "interactive", "noninteractive", or nil
     @widget = widget # Set only when widget is rendered inside the widget panel
   end
 
   def before_render
-    @library_mode ||= params[:library_mode]
+    @preview_mode ||= params[:preview_mode]
     @error = nil
     @error_with_api = false
     begin

--- a/app/components/dev_widget_preview/dev_widget_preview_component.html.erb
+++ b/app/components/dev_widget_preview/dev_widget_preview_component.html.erb
@@ -1,0 +1,26 @@
+<% if params["mode"] == "expanded" %>
+
+  <%# Expanded widget (fake modal) %>
+  <%= render(ExpandedWidgetComponent.new(widget: @widget, preview_mode: "interactive")) do %>
+    <iframe src="<%= @iframe_url %>" class="w-full h-full"></iframe>
+  <% end %>
+
+  <%= javascript_include_tag "dev_widget_preview_component_expanded" %>
+
+<% elsif params["mode"] == "library" %>
+
+  <%# Library tile %>
+  <%= stylesheet_link_tag "widget_panel/style" %>
+  <div class="mx-auto rounded-lg overflow-hidden border shadow-drop" style="width: var(--library-tile-width)">
+    <%= render partial: "component/library_tile", locals: {widget: @widget, widgets: []} %>
+  </div>
+
+<% else %>
+
+  <%# Inline widget %>
+  <div class="mx-auto" style="width: var(--inline-widget-width)">
+    <%= render(InlineWidgetComponent.new(widget: @widget, expand_url: @expand_url, preview_mode: "interactive")) do %>
+      <iframe src="<%= @iframe_url %>" class="flex-1" style="width: var(--inline-widget-iframe-width)"></iframe>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/dev_widget_preview/dev_widget_preview_component.rb
+++ b/app/components/dev_widget_preview/dev_widget_preview_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DevWidgetPreview::DevWidgetPreviewComponent < ApplicationComponent
+  include Components::ExternalWidgetHelper
+
+  def before_render
+    super
+    return if @error.present?
+    @widget = Widget.new({
+      component: "external_widget_preview",
+      external_url: params["url"],
+      name: params["widget_name"] || "New Widget",
+      description: params["description"] || "Your description will appear here once entered.",
+      partner: params["partner"] || "",
+      logo_link_url: params["logo_link_url"]
+    })
+    @iframe_url = populate_url_variables(params["url"], true)
+  end
+end

--- a/app/components/expanded_widget_component.html.erb
+++ b/app/components/expanded_widget_component.html.erb
@@ -1,23 +1,65 @@
-<mx-modal large close-on-escape="false" class="<%= @widget.component %>">
-  <div slot="header-left" class="pr-48"><%= @modal_heading %></div>
-  <div slot="header-right" class="flex items-center space-x-16">
-    <mx-button class="close-button" btn-type="text">Close</mx-button>
+<% unless @preview_mode.present? %>
+  <%# Expanded Modal %>
+  <mx-modal large close-on-escape="false" class="<%= @widget.component %>">
+    <div slot="header-left" class="pr-48"><%= @modal_heading %></div>
+    <div slot="header-right" class="flex items-center space-x-16">
+      <mx-button class="close-button" btn-type="text">Close</mx-button>
+    </div>
+
+    <%= content %>
+
+    <div slot="footer-left">
+      <% if @widget.logo.attached? %>
+        <a href="<%= @widget.logo_link_url %>" target="_blank">
+          <img id="logo" src="<%= @widget.logo_url %>" width="105" height="48" alt="<%= @widget.partner %>" />
+        </a>
+      <% end %>
+    </div>
+  </mx-modal>
+
+  <%= javascript_include_tag "expanded_widget_component" %>
+
+  <script type="module">
+  window.WidgetFactory.SESSION_ID = '<%= params[:session_id] %>';
+  window.WidgetFactory.setUpModal('<%= @widget.component %>');
+  </script>
+
+<% else %>
+  <%# Preview (fake modal) %>
+  <style>
+    html, body {
+      height: 100%;
+    }
+  </style>
+
+  <div class="p-4 h-full">
+    <div class="flex flex-col h-full rounded border bg-white shadow-drop mx-auto" style="max-width: 75rem">
+      <header class="flex items-center h-80 px-40">
+        <div role="heading" aria-level="1" class="text-h2 text-primary">
+          <%= @widget.name %>
+        </div>
+      </header>
+      <div class="flex-1 border-b">
+
+        <%= content %>
+
+      </div>
+      <footer class="flex items-center h-80 px-40">
+        <% if @widget.logo_link_url.present? %>
+          <a href="<%= @widget.logo_link_url %>" target="_blank">
+        <% end %>
+        <img
+          id="logo"
+          class="<%= @widget.logo_url.present? ? "" : "hidden" %>"
+          src="<%= @widget.logo_url %>"
+          width="105"
+          height="48"
+          alt="<%= @widget.partner %>"
+        />
+        <% if @widget.logo_link_url.present? %>
+          </a>
+        <% end %>
+      </div>
+    </div>
   </div>
-
-  <%= content %>
-
-  <div slot="footer-left">
-    <% if @widget.logo.attached? %>
-      <a href="<%= @widget.logo_link_url %>" target="_blank">
-        <img id="logo" src="<%= @widget.logo_url %>" width="105" height="48" alt="<%= @widget.partner %>" />
-      </a>
-    <% end %>
-  </div>
-</mx-modal>
-
-<%= javascript_include_tag "expanded_widget_component" %>
-
-<script type="module">
-window.WidgetFactory.SESSION_ID = '<%= params[:session_id] %>';
-window.WidgetFactory.setUpModal('<%= @widget.component %>');
-</script>
+<% end %>

--- a/app/components/expanded_widget_component.rb
+++ b/app/components/expanded_widget_component.rb
@@ -1,6 +1,7 @@
 class ExpandedWidgetComponent < ViewComponent::Base
-  def initialize(widget:, modal_heading: nil)
+  def initialize(widget:, modal_heading: nil, preview_mode: nil)
     @widget = widget
     @modal_heading = modal_heading || widget.name
+    @preview_mode = preview_mode
   end
 end

--- a/app/components/external_widget/external_widget_component.html.erb
+++ b/app/components/external_widget/external_widget_component.html.erb
@@ -3,7 +3,7 @@
     <iframe src="<%= @expanded_iframe_url %>" class="w-full h-full"></iframe>
   <% end %>
 <% else %>
-  <%= render(InlineWidgetComponent.new(widget: @widget, expand_url: @expand_url, library_mode: @library_mode)) do %>
-    <iframe src="<%= @iframe_url %>" class="flex-1" style="width: 18.375rem"></iframe>
+  <%= render(InlineWidgetComponent.new(widget: @widget, expand_url: @expand_url, preview_mode: @preview_mode)) do %>
+    <iframe src="<%= @iframe_url %>" class="flex-1" style="width: var(--inline-widget-iframe-width)"></iframe>
   <% end %>
 <% end %>

--- a/app/components/external_widget/external_widget_component.rb
+++ b/app/components/external_widget/external_widget_component.rb
@@ -7,9 +7,9 @@ class ExternalWidget::ExternalWidgetComponent < ApplicationComponent
     super
     return if @error.present?
     external_url = @widget.external_url
-    external_url = @widget.external_preview_url if @library_mode && @widget.external_preview_url.present?
+    external_url = @widget.external_preview_url if @preview_mode == "noninteractive" && @widget.external_preview_url.present?
     submission_preview = ["unsubmitted", "review", "rejected"].include?(@widget.status)
-    demo = @library_mode || submission_preview # use demo values for library or submission preview
+    demo = @preview_mode.present? || submission_preview # use demo values for library or submission preview
     @iframe_url = populate_url_variables(external_url, demo)
     if @widget.external_expanded_url.present?
       @expand_url = component_named_expanded_path(@widget.component, params[:session_id])

--- a/app/components/hurdlr/hurdlr_component.html.erb
+++ b/app/components/hurdlr/hurdlr_component.html.erb
@@ -1,6 +1,6 @@
 <%= stylesheet_link_tag "hurdlr/style" %>
 
-<%= render(InlineWidgetComponent.new(widget: @widget, library_mode: @library_mode, error: @error)) do %>
+<%= render(InlineWidgetComponent.new(widget: @widget, preview_mode: @preview_mode, error: @error)) do %>
   <div class="relative flex items-center flex-1 subtitle4 p-16">
     <table
       class="w-full"

--- a/app/components/hurdlr/hurdlr_component.rb
+++ b/app/components/hurdlr/hurdlr_component.rb
@@ -4,7 +4,7 @@ class Hurdlr::HurdlrComponent < ApplicationComponent
   def before_render
     super
     return if @error.present?
-    @data = @library_mode ? demo_data : user_vitals
+    @data = @preview_mode.present? ? demo_data : user_vitals
   end
 
   def user_vitals

--- a/app/components/inline_widget_component.html.erb
+++ b/app/components/inline_widget_component.html.erb
@@ -1,7 +1,7 @@
 <div
   data-expanded-url="<%= @expand_url %>"
-  class="<%= @widget.component %> <%= "pointer-events-none" if @library_mode %> inline-widget relative flex flex-col border text-primary shadow-drop rounded overflow-hidden m-8"
-  <%= "inert" if @library_mode %>
+  class="<%= @widget.component %> <%= "pointer-events-none" if @preview_mode == "noninteractive" %> inline-widget relative flex flex-col border text-primary shadow-drop rounded overflow-hidden m-8"
+  <%= "inert" if @preview_mode == "noninteractive" %>
 >
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
     <p id="heading" role="heading" aria-level="2" class="my-0 subtitle3">
@@ -15,25 +15,25 @@
     <%= render "component/spinner" %>
   </div>
 
-  <% wrap_logo_with_link = !@library_mode && @widget.logo_link_url.present? %>
-  <% justify_class = @widget.logo_url.present? ? "justify-between" : "justify-end" %>
-  <footer class="flex items-center <%= justify_class %> min-h-48 bg-white border-t px-16">
-    <% if @widget.logo_url.present? %>
+  <% wrap_logo_with_link = @preview_mode != "noninteractive" && @widget.logo_link_url.present? %>
+  <footer class="flex items-center justify-between min-h-48 bg-white border-t px-16">
+    <div class="flex items-center">
       <% if wrap_logo_with_link %>
-        <a href="<%= @widget.logo_link_url %>" target="_blank">
+        <a href="<%= @widget.logo_link_url %>" class="inline-block" target="_blank">
       <% end %>
       <img
         id="logo"
         src="<%= @widget.logo_url %>"
         alt="<%= @widget.partner %>"
+        class="<%= @widget.logo_url.present? ? "" : "hidden" %>"
         style="max-height: 1.875rem;"
       />
       <% if wrap_logo_with_link %>
         </a>
       <% end %>
-    <% end %>
+    </div>
     <div class="actions flex items-center space-x-8">
-      <% unless @library_mode %>
+      <% unless @preview_mode.present? %>
         <% if @expand_url.present? %>
           <button class="expand-button flex items-center cursor-pointer" aria-label="Expand widget">
             <span class="icon icon-grow"></span>

--- a/app/components/inline_widget_component.rb
+++ b/app/components/inline_widget_component.rb
@@ -1,8 +1,8 @@
 class InlineWidgetComponent < ViewComponent::Base
-  def initialize(widget:, expand_url: nil, library_mode: false, error: nil)
+  def initialize(widget:, expand_url: nil, preview_mode: nil, error: nil)
     @widget = widget
     @expand_url = expand_url
-    @library_mode = library_mode
+    @preview_mode = preview_mode
     @error = error
   end
 end

--- a/app/components/list_trac/list_trac_component.html.erb
+++ b/app/components/list_trac/list_trac_component.html.erb
@@ -19,7 +19,7 @@
 <% else %>
 
   <%# Inline Widget %>
-  <%= render(InlineWidgetComponent.new(widget: @widget, expand_url: @expand_url, library_mode: @library_mode, error: @error)) do %>
+  <%= render(InlineWidgetComponent.new(widget: @widget, expand_url: @expand_url, preview_mode: @preview_mode, error: @error)) do %>
     <div class="flex-1 py-12 px-16 bg-gray relative min-w-0 max-w-full overflow-hidden">
       <table class="w-full max-w-full overflow-hidden min-w-0 rounded bg-white shadow-1" cellspacing="0">
         <thead class="h-32">

--- a/app/components/list_trac/list_trac_component.rb
+++ b/app/components/list_trac/list_trac_component.rb
@@ -6,8 +6,8 @@ class ListTrac::ListTracComponent < ApplicationComponent
     return if @error.present?
     @listings = []
     begin
-      @token = token unless @library_mode
-      @listings = @library_mode ? demo_listings : agent_listings
+      @token = token unless @preview_mode.present?
+      @listings = @preview_mode.present? ? demo_listings : agent_listings
       @expand_url = @listings.any? ? component_named_expanded_path(@widget.component, params[:session_id]) : nil
       @listings = @listings.sort_by { |listing| listing[:ViewCount] }.reverse
     rescue => e

--- a/app/components/rismedia/rismedia_component.html.erb
+++ b/app/components/rismedia/rismedia_component.html.erb
@@ -58,7 +58,7 @@
 <% else %>
 
   <%# Inline Widget %>
-  <%= render(InlineWidgetComponent.new(widget: @widget, expand_url: @expand_url, library_mode: @library_mode, error: @error)) do %>
+  <%= render(InlineWidgetComponent.new(widget: @widget, expand_url: @expand_url, preview_mode: @preview_mode, error: @error)) do %>
     <div class="flex-1 py-12 px-16 min-w-0 max-w-full bg-white overflow-hidden">
       <nav>
         <div role="tablist" class="flex mb-12 h-24 border-b text-medium-emphasis border-current">

--- a/app/components/tips/tips_component.html.erb
+++ b/app/components/tips/tips_component.html.erb
@@ -1,8 +1,8 @@
 <%= stylesheet_link_tag "tips/style" %>
 
-<%= render(InlineWidgetComponent.new(widget: @widget, library_mode: @library_mode)) do %>
+<%= render(InlineWidgetComponent.new(widget: @widget, preview_mode: @preview_mode)) do %>
   <div class="flex flex-1 py-12 px-16 tip-bg" style="--tip-bg: var(--tip-bg-<%= @bg %>)">
-    <div data-tip-id="<%= @id %>" class="tip-container w-full flex-1 flex flex-col-reverse items-center justify-center p-12 rounded <%= @library_mode ? "pointer-events-none" : "" %>">
+    <div data-tip-id="<%= @id %>" class="tip-container w-full flex-1 flex flex-col-reverse items-center justify-center p-12 rounded <%= @preview_mode.present? ? "pointer-events-none" : "" %>">
       <% if @cta_label.present? %>
         <mx-button btn-type="text" href="<%= @cta_url %>" class="max-w-full" target="_blank">
           <%= @cta_label %>

--- a/app/components/widget_panel/widget_panel_component.html.erb
+++ b/app/components/widget_panel/widget_panel_component.html.erb
@@ -50,36 +50,7 @@ window.WidgetFactory.SESSION_ID = '<%= params[:session_id] %>';
   <mx-modal large close-on-escape="false">
     <div slot="header-left">Library</div>
     <div class="widget-library-grid">
-      <% @active_widgets.each do |widget| %>
-        <% added = @widgets.include?(widget) %>
-        <div data-widget-id="<%= widget.id %>" data-widget-component="<%= widget.component %>" class="px-16 pt-16 pb-24 bg-white rounded">
-          <div class="px-8 mb-20">
-            <mx-button btn-type="text" icon="icon icon-plus-circle" class="add-button <%= added ? "hidden" : "" %>">
-              <span class="button-text">Add widget</span>
-            </mx-button>
-            <div class="remove-button-wrapper relative <%= added ? "" : "hidden" %>">
-              <!-- It was cleaner to do this with two buttons and CSS instead of JavaScript. -->
-              <!-- Remove button that is hovered/focused/active.  -->
-              <mx-button btn-type="text" icon="icon icon-minus-circle" class="remove-button absolute left-0 opacity-0 hover:opacity-100 focus-within:opacity-100">
-                <span class="button-text">Remove from Dashboard</span>
-              </mx-button>
-              <!-- Not hovered/focused/active -->
-              <mx-button btn-type="text" icon="icon icon-checkbox-circle" class="added-button pointer-events-none" disabled>
-                Added to Dashboard
-              </mx-button>
-            </div>
-          </div>
-          <%= render widget.view_component.new(library_mode: true, widget: widget) %>
-          <div class="px-8 mt-20">
-            <p role="heading" aria-level="3" class="overline2 my-0 mb-8">
-              Description
-            </p>
-            <p class="text-4 my-0">
-              <%= widget.description %>
-            </p>
-          </div>
-        </div>
-      <% end %>
+      <%= render partial: "component/library_tile", collection: @active_widgets, as: :widget, locals: {widgets: @widgets} %>
     </div>
   </mx-modal>
 </div>

--- a/app/controllers/api/widgets_controller.rb
+++ b/app/controllers/api/widgets_controller.rb
@@ -46,7 +46,7 @@ class Api::WidgetsController < ApplicationController
       @widget.destroy
       head :no_content
     else
-      render json: { error: "Widget cannot be deleted" }, status: :unprocessable_entity
+      render json: {error: "Widget cannot be deleted"}, status: :unprocessable_entity
     end
   end
 

--- a/app/views/component/_library_tile.html.erb
+++ b/app/views/component/_library_tile.html.erb
@@ -1,0 +1,28 @@
+<% added = widgets.include?(widget) %>
+<div data-widget-id="<%= widget.id %>" data-widget-component="<%= widget.component %>" class="px-16 pt-16 pb-24 bg-white rounded" data-testid="library-tile">
+  <div class="px-8 mb-20">
+    <mx-button btn-type="text" icon="icon icon-plus-circle" class="add-button <%= added ? "hidden" : "" %>">
+      <span class="button-text">Add widget</span>
+    </mx-button>
+    <div class="remove-button-wrapper relative <%= added ? "" : "hidden" %>">
+      <!-- It was cleaner to do this with two buttons and CSS instead of JavaScript. -->
+      <!-- Remove button that is hovered/focused/active.  -->
+      <mx-button btn-type="text" icon="icon icon-minus-circle" class="remove-button absolute left-0 opacity-0 hover:opacity-100 focus-within:opacity-100">
+        <span class="button-text">Remove from Dashboard</span>
+      </mx-button>
+      <!-- Not hovered/focused/active -->
+      <mx-button btn-type="text" icon="icon icon-checkbox-circle" class="added-button pointer-events-none" disabled>
+        Added to Dashboard
+      </mx-button>
+    </div>
+  </div>
+  <%= render widget.view_component.new(preview_mode: "noninteractive", widget: widget) %>
+  <div class="px-8 mt-20">
+    <p role="heading" aria-level="3" class="overline2 my-0 mb-8">
+      Description
+    </p>
+    <p class="text-4 my-0">
+      <%= widget.description %>
+    </p>
+  </div>
+</div>

--- a/config/initializers/mds_version.rb
+++ b/config/initializers/mds_version.rb
@@ -1,1 +1,1 @@
-Rails.application.config.mds_version = "0.7.0"
+Rails.application.config.mds_version = "0.10.0"

--- a/test/components/dev_widget_preview/dev_widget_preview_component_test.rb
+++ b/test/components/dev_widget_preview/dev_widget_preview_component_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DevWidgetPreviewComponentTest < ViewComponent::TestCase
+  def setup
+    # setup any necessary state here
+  end
+
+  def test_component_renders_expanded_mode
+    with_request_url "/component/dev_widget_preview/12345?widget_name=Test+Widget&description=My+widget+description&mode=expanded&url=https://example.com/{MLS_NUMBER}/{NRDS_NUMBER}/{FULL_NAME}?expanded" do
+      render_inline(DevWidgetPreview::DevWidgetPreviewComponent.new)
+      assert_selector "header", text: "Test Widget"
+      assert_selector("iframe[src='https://example.com/123456/123456789/Jane+Doe?expanded']")
+    end
+  end
+
+  def test_component_renders_library_mode
+    with_request_url "/component/dev_widget_preview/12345?widget_name=Test+Widget&description=My+widget+description&mode=library&url=https://example.com/111111/111111111/Test%20User" do
+      rendered = render_inline(DevWidgetPreview::DevWidgetPreviewComponent.new)
+      assert_selector "[data-testid='library-tile']", text: "My widget description"
+      assert_match(/iframe src="https:\/\/example.com\/111111\/111111111\/Test%20User"/, rendered.to_html)
+    end
+  end
+
+  def test_component_renders_inline_mode
+    with_request_url "/component/dev_widget_preview/12345?widget_name=Test+Widget&description=My+widget+description&mode=inline&url=https://example.com/{MLS_NUMBER}/{NRDS_NUMBER}/{FULL_NAME}" do
+      render_inline(DevWidgetPreview::DevWidgetPreviewComponent.new)
+      assert_selector "header", text: "Test Widget"
+      assert_selector("iframe[src='https://example.com/123456/123456789/Jane+Doe']")
+    end
+  end
+end

--- a/test/components/external_widget/external_widget_component_test.rb
+++ b/test/components/external_widget/external_widget_component_test.rb
@@ -10,6 +10,7 @@ class ExternalWidgetComponentTest < ViewComponent::TestCase
       component: "external_test",
       partner: "MoxiWorks",
       external_url: "https://example.com/{MLS_NUMBER}/{NRDS_NUMBER}/{FULL_NAME}",
+      external_expanded_url: "https://example.com/{MLS_NUMBER}/{NRDS_NUMBER}/{FULL_NAME}?expanded",
       external_preview_url: "https://example.com/preview/{MLS_NUMBER}/{NRDS_NUMBER}/{FULL_NAME}"
     )
     @widget.logo.attach(io: File.open(Rails.root.join("test", "fixtures", "files", "logo.png")), filename: "logo.png", content_type: "image/png")
@@ -17,18 +18,43 @@ class ExternalWidgetComponentTest < ViewComponent::TestCase
   end
 
   def test_component_renders_submission_preview
-    render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget))
-    assert_selector("iframe[src='https://example.com/123456/123456789/Jane+Doe']")
+    with_inline_component do
+      render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget))
+      assert_selector("iframe[src='https://example.com/123456/123456789/Jane+Doe']")
+    end
+  end
+
+  def test_component_renders_expanded_submission_preview
+    with_expanded_component do
+      render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget))
+      assert_selector("iframe[src='https://example.com/111111/111111111/Test+User?expanded']")
+    end
   end
 
   def test_component_renders_library_preview
-    render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget, library_mode: true))
-    assert_selector("iframe[src='https://example.com/preview/123456/123456789/Jane+Doe']")
+    with_inline_component do
+      render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget, preview_mode: "noninteractive"))
+      assert_selector("iframe[src='https://example.com/preview/123456/123456789/Jane+Doe']")
+    end
   end
 
   def test_component_renders_live_url
     @widget.status = "ready"
-    render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget))
-    assert_selector("iframe[src='https://example.com/111111/111111111/Test+User']")
+    with_inline_component do
+      render_inline(ExternalWidget::ExternalWidgetComponent.new(widget: @widget))
+      assert_selector("iframe[src='https://example.com/111111/111111111/Test+User']")
+    end
+  end
+
+  def with_inline_component
+    with_request_url "/component/external_test/12345" do
+      yield
+    end
+  end
+
+  def with_expanded_component
+    with_request_url "/component/external_test/expanded/12345" do
+      yield
+    end
   end
 end

--- a/test/components/hurdlr/hurdlr_component_test.rb
+++ b/test/components/hurdlr/hurdlr_component_test.rb
@@ -28,6 +28,6 @@ class Hurdlr::HurdlrComponentTest < ViewComponent::TestCase
   private
 
   def rendered
-    render_inline(Hurdlr::HurdlrComponent.new(library_mode: true))
+    render_inline(Hurdlr::HurdlrComponent.new(preview_mode: "noninteractive"))
   end
 end

--- a/test/components/inline_widget_component_test.rb
+++ b/test/components/inline_widget_component_test.rb
@@ -54,8 +54,8 @@ class InlineWidgetComponentTest < ViewComponent::TestCase
     assert_selector expand_button
   end
 
-  def test_component_library_mode
-    render_inline(InlineWidgetComponent.new(widget: @widget, library_mode: true, expand_url: "https://moxiworks.com"))
+  def test_component_preview_mode
+    render_inline(InlineWidgetComponent.new(widget: @widget, preview_mode: "noninteractive", expand_url: "https://moxiworks.com"))
     assert_selector "div.#{@widget[:component]}.pointer-events-none[inert]"
     assert_no_selector "a"
     assert_no_selector "button"

--- a/test/components/list_trac/list_trac_component_test.rb
+++ b/test/components/list_trac/list_trac_component_test.rb
@@ -44,7 +44,7 @@ class ListTrac::ListTracComponentTest < ViewComponent::TestCase
   private
 
   def rendered
-    render_inline(ListTrac::ListTracComponent.new(library_mode: true))
+    render_inline(ListTrac::ListTracComponent.new(preview_mode: "noninteractive"))
   end
 
   def with_inline_component

--- a/test/components/rismedia/rismedia_component_test.rb
+++ b/test/components/rismedia/rismedia_component_test.rb
@@ -76,7 +76,7 @@ class Rismedia::RismediaComponentTest < ViewComponent::TestCase
   private
 
   def rendered
-    render_inline(Rismedia::RismediaComponent.new(library_mode: true))
+    render_inline(Rismedia::RismediaComponent.new(preview_mode: "noninteractive"))
   end
 
   def with_inline_component

--- a/test/components/tips/tips_component_test.rb
+++ b/test/components/tips/tips_component_test.rb
@@ -43,7 +43,7 @@ class Tips::TipsComponentTest < ViewComponent::TestCase
   private
 
   def rendered
-    render_inline(Tips::TipsComponent.new(library_mode: false))
+    render_inline(Tips::TipsComponent.new)
   end
 
   def my_tip

--- a/test/components/widget_panel/widget_panel_component_test.rb
+++ b/test/components/widget_panel/widget_panel_component_test.rb
@@ -146,7 +146,7 @@ class WidgetPanel::WidgetPanelComponentTest < ViewComponent::TestCase
   private
 
   def rendered
-    render_inline(WidgetPanel::WidgetPanelComponent.new(library_mode: true))
+    render_inline(WidgetPanel::WidgetPanelComponent.new(preview_mode: "noninteractive"))
   end
 
   def with_inline_component(components = [])


### PR DESCRIPTION
## Description

- Added a new `DevWidgetPreviewComponent` that is specifically used to render the developer portal submission previews.  This new component builds up a `Widget` object from URL query params and supports three "modes": inline, expanded, and library.  I did not want to complicate the existing `ExternalWidgetComponent` further by trying to make it work for both the database records and the query params, not to mention adding the Library preview, so that's why I went with a new component.
- Replaced the `library_mode` param that is passed down through various components with `preview_mode`.  Whereas `library_mode` was a boolean, `preview_mode` can be either "noninteractive" (for the library and admin form previews), "interactive" (for the developer portal preview), or `nil` for the live widget.  This change touched a lot of files.
- Updated the `ExpandedWidgetComponent` to render a "fake" modal for previewing per the design.
- Factored out a `library_tile` partial to use in both the library (`WidgetPanelComponent`) and the developer portal library preview.

There is a corresponding PR in nucleus as well. https://github.com/moxiworks/nucleus/pull/824

<img width="414" alt="image" src="https://github.com/moxiworks/widget-factory/assets/3342530/98af5fb7-a10d-4e9c-bc2a-c47898565478">

<img width="1227" alt="image" src="https://github.com/moxiworks/widget-factory/assets/3342530/bcda972a-09ee-4c97-9a34-3d0ea19eecc8">

<img width="457" alt="image" src="https://github.com/moxiworks/widget-factory/assets/3342530/b2af3944-34ac-4150-97f9-6276c6b2d244">


## JIRA Link
https://moxiworks.atlassian.net/browse/OT-200
