### PR TITLE
Return "unsubmitted" if status is nil

### DIFF
--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -34,6 +34,10 @@ class Widget < ApplicationRecord
     super
   end
 
+  def status
+    super || "unsubmitted"
+  end
+
   def activated
     status == Widget.statuses[:ready] && (activation_date.blank? || activation_date <= Time.zone.now)
   end


### PR DESCRIPTION
## Description

If a widget record somehow ends up with a nil `status` in the database (i.e. during testing), return "unsubmitted" any time that record's status is requested.
