### PR TITLE
Implement revising widget submissions

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :widgets
+    patch "widgets/:id/revise" => "widgets#revise"
+    patch "widgets/:id/merge" => "widgets#merge"
     post "events" => "events#create"
     patch "user_widgets", to: "user_widgets#update_order"
     delete "user_widgets/:id", to: "user_widgets#destroy", as: :destroy_user_widget

--- a/db/migrate/20230906144146_add_parent_widget_id_to_widgets.rb
+++ b/db/migrate/20230906144146_add_parent_widget_id_to_widgets.rb
@@ -1,0 +1,5 @@
+class AddParentWidgetIdToWidgets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :widgets, :parent_widget_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_19_163802) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_144146) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,6 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_19_163802) do
     t.datetime "submitted_at"
     t.string "submitted_by_uuid"
     t.text "submission_notes"
+    t.integer "parent_widget_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/fixtures/widgets.yml
+++ b/test/fixtures/widgets.yml
@@ -29,3 +29,17 @@ three:
   status: submitted
   activation_date: 2023-01-23 09:04:27
   updated_by: MyString
+
+four:
+  component: widget_four
+  partner: MyString
+  name: Widget Four
+  description: New Description
+  logo_link_url: New Link
+  status: unsubmitted
+  activation_date: 2023-01-23 09:04:27
+  updated_by: MyString
+  parent_widget: one
+  external_url: https://www.example.com
+  external_expanded_url: https://www.example.com
+  external_preview_url: https://www.example.com


### PR DESCRIPTION
## Description

- Added `revise` and `merge` endpoints.  The `revise` endpoint creates a draft revision of a widget.  The `merge` endpoint then merges the revision back into the parent widget.
- Updated the `index` and `show` actions to include the revision and parent widget info
- Changed the `add_submission_log` callback to create a log when saving a draft (per design change).
- Changed `add_submission_log` to allow changing "review" status to "draft" per design changes.
- Changed the logic for when a widget can be deleted (approved edits can be deleted prior to merging), and moved this logic into a `can_destroy?` method.
- Updated tests

This PR is a prerequisite for https://github.com/moxiworks/nucleus/pull/827 in nucleus.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-203

## Validation Steps
- Edit an approved widget from the dev portal
- Merge using the nucleus admin page
- Verify the process functions correctly per the design
