### PR TITLE
OT-235 - Do not pad iframe in expanded widget modal

### DIFF
--- a/app/components/expanded_widget_component.html.erb
+++ b/app/components/expanded_widget_component.html.erb
@@ -1,6 +1,11 @@
 <% unless @preview_mode.present? %>
   <%# Expanded Modal %>
-  <mx-modal large close-on-escape="false" class="<%= @widget.component %>">
+  <mx-modal
+    large
+    <%= "unpadded" if @widget.external_expanded_url.present? %>
+    close-on-escape="false"
+    class="<%= @widget.component %>"
+  >
     <div slot="header-left" class="pr-48"><%= @modal_heading %></div>
     <div slot="header-right" class="flex items-center space-x-16">
       <mx-button class="close-button" btn-type="text">Close</mx-button>


### PR DESCRIPTION
## Description

This updates the expanded widget modal to use the new `mx-modal` `unpadded` prop to remove the padding around the iframe.

### Before (scrollbar looks weird)
<img width="951" alt="image" src="https://github.com/moxiworks/widget-factory/assets/3342530/63c88d6d-9f25-4574-9c32-968abb9d83cd">


### After
<img width="945" alt="image" src="https://github.com/moxiworks/widget-factory/assets/3342530/7ef240f6-6bae-42e6-bd50-eb9c947a3111">


## JIRA Link
https://moxiworks.atlassian.net/browse/OT-235
