### PR TITLE
Remove expanded widget modal's custom close button

### DIFF
--- a/app/assets/javascripts/expanded_widget_component.js
+++ b/app/assets/javascripts/expanded_widget_component.js
@@ -36,9 +36,6 @@ function addCloseHandlers() {
   const modal = document.querySelector('mx-modal');
   modal.addEventListener('mxClose', sendCloseMessage);
 
-  const closeButton = document.querySelector('.close-button');
-  closeButton.addEventListener('click', sendCloseMessage);
-
   document.addEventListener('keydown', e => {
     if (e.key === 'Escape') sendCloseMessage();
   });

--- a/app/components/expanded_widget_component.html.erb
+++ b/app/components/expanded_widget_component.html.erb
@@ -7,9 +7,6 @@
     class="<%= @widget.component %>"
   >
     <div slot="header-left" class="pr-48"><%= @modal_heading %></div>
-    <div slot="header-right" class="flex items-center space-x-16">
-      <mx-button class="close-button" btn-type="text">Close</mx-button>
-    </div>
 
     <%= content %>
 


### PR DESCRIPTION
## Description

This removes the custom close button from the expanded widget modal.  The modal will now use the default slot content, which is an icon button in the latest modal component.

### Before
![image](https://github.com/moxiworks/widget-factory/assets/3342530/bf4b084b-a424-4587-b21c-3c78abb2e02b)

### After
![image](https://github.com/moxiworks/widget-factory/assets/3342530/ef4cbd10-6579-4001-b7c2-b7b486169f8e)
