### PR TITLE
OT-237 - Ensure external urls have http(s) protocol

### DIFF
--- a/app/helpers/components/external_widget_helper.rb
+++ b/app/helpers/components/external_widget_helper.rb
@@ -1,5 +1,6 @@
 module Components::ExternalWidgetHelper
   def populate_url_variables(url, demo = false)
+    url = "https://#{url}" unless url.start_with?("http")
     return url unless url.include?("{")
     variables = if demo
       demo_values


### PR DESCRIPTION
## Description

The developer portal submission form already prepends external URLs with "https://" if no protocol is provided.  However, that only happens on save, so the previews might still try to use a URL without a protocol.

This PR ensures that any external URLs passed to the `external_widget` or `dev_widget_preview` components get the http(s) protocol.

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-237

## Validation Steps
Create a new widget.  Enter something like `moxiworks.github.io/demo-widget/?mls-number={MLS_NUMBER}&nrds-number={NRDS_NUMBER}&full-name={FULL_NAME}` for one of the external URLs, and click Preview.  The preview should work.