### PR TITLE
OT-238 - Fix expanded widget logo dimensions

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -34,6 +34,10 @@ body {
 .inline-widget {
   min-height: 18.5rem; /* 296px */
 }
+.expanded-widget img#logo {
+  max-width: 6.5625rem;
+  max-height: 3rem;
+}
 .icon {
   --svg: ; /* Set in the .icon-* classes */
   display: inline-flex;

--- a/app/components/expanded_widget_component.html.erb
+++ b/app/components/expanded_widget_component.html.erb
@@ -4,7 +4,7 @@
     large
     <%= "unpadded" if @widget.external_expanded_url.present? %>
     close-on-escape="false"
-    class="<%= @widget.component %>"
+    class="<%= @widget.component %> expanded-widget"
   >
     <div slot="header-left" class="pr-48"><%= @modal_heading %></div>
 
@@ -13,7 +13,7 @@
     <div slot="footer-left">
       <% if @widget.logo.attached? %>
         <a href="<%= @widget.logo_link_url %>" target="_blank">
-          <img id="logo" src="<%= @widget.logo_url %>" width="105" height="48" alt="<%= @widget.partner %>" />
+          <img id="logo" src="<%= @widget.logo_url %>" alt="<%= @widget.partner %>" />
         </a>
       <% end %>
     </div>
@@ -34,7 +34,7 @@
     }
   </style>
 
-  <div class="p-4 h-full">
+  <div class="expanded-widget p-4 h-full">
     <div class="flex flex-col h-full rounded border bg-white shadow-drop mx-auto" style="max-width: 75rem">
       <header class="flex items-center h-80 px-40">
         <div role="heading" aria-level="1" class="text-h2 text-primary">
@@ -54,8 +54,6 @@
           id="logo"
           class="<%= @widget.logo_url.present? ? "" : "hidden" %>"
           src="<%= @widget.logo_url %>"
-          width="105"
-          height="48"
           alt="<%= @widget.partner %>"
         />
         <% if @widget.logo_link_url.present? %>


### PR DESCRIPTION
## Description

This removes the `width` and `height` attributes from the expanded widget modal logo, which act as minimums, and replaces them with `max-width` and `max-height`.  This should ensure that no logo overflows the modal footer.

### Before
![image](https://github.com/moxiworks/widget-factory/assets/3342530/34fd3937-a8b3-4e24-a6f0-84461e0de12f)

### After
![image](https://github.com/moxiworks/widget-factory/assets/3342530/faf3f01c-c0aa-49cb-882d-1381bab13b73)


## JIRA Link
https://moxiworks.atlassian.net/browse/OT-238

## Validation Steps
Choose a square logo on the widget submission form, and preview an external url.  The logo should be constrained to 105x48px.
