### PR TITLE
OT-244 - Handle long widget name or description

### DIFF
--- a/app/assets/javascripts/dev_widget_preview_component_library.js
+++ b/app/assets/javascripts/dev_widget_preview_component_library.js
@@ -1,0 +1,9 @@
+// Notify parent window of height changes (due to description text wrapping)
+const resizeObserver = new ResizeObserver(entries => {
+  const height = entries[0].contentRect.height;
+  window.parent.postMessage(
+    { type: 'RESIZE', payload: { component: 'dev_widget_preview', height } },
+    '*'
+  );
+});
+resizeObserver.observe(document.body);

--- a/app/components/dev_widget_preview/dev_widget_preview_component.html.erb
+++ b/app/components/dev_widget_preview/dev_widget_preview_component.html.erb
@@ -15,6 +15,8 @@
     <%= render partial: "component/library_tile", locals: {widget: @widget, widgets: []} %>
   </div>
 
+  <%= javascript_include_tag "dev_widget_preview_component_library" %>
+
 <% else %>
 
   <%# Inline widget %>

--- a/app/components/expanded_widget_component.html.erb
+++ b/app/components/expanded_widget_component.html.erb
@@ -37,7 +37,7 @@
   <div class="expanded-widget p-4 h-full">
     <div class="flex flex-col h-full rounded border bg-white shadow-drop mx-auto" style="max-width: 75rem">
       <header class="flex items-center h-80 px-40">
-        <div role="heading" aria-level="1" class="text-h2 text-primary">
+        <div role="heading" aria-level="1" class="text-h2 text-primary truncate">
           <%= @widget.name %>
         </div>
       </header>

--- a/app/components/inline_widget_component.html.erb
+++ b/app/components/inline_widget_component.html.erb
@@ -4,7 +4,7 @@
   <%= "inert" if @preview_mode == "noninteractive" %>
 >
   <header class="flex items-center min-h-48 bg-white border-b px-16 select-none">
-    <p id="heading" role="heading" aria-level="2" class="my-0 subtitle3">
+    <p id="heading" role="heading" aria-level="2" class="my-0 subtitle3 truncate">
       <%= @widget.name %>
     </p>
   </header>

--- a/app/views/component/_library_tile.html.erb
+++ b/app/views/component/_library_tile.html.erb
@@ -21,7 +21,7 @@
     <p role="heading" aria-level="3" class="overline2 my-0 mb-8">
       Description
     </p>
-    <p class="text-4 my-0">
+    <p class="text-4 my-0 overflow-hidden" style="overflow-wrap: anywhere">
       <%= widget.description %>
     </p>
   </div>


### PR DESCRIPTION
## Description

This adds truncation and wrapping to better handle long input text for the widget name and description.

For the description, this required dispatching a resize event to the nucleus preview iframe since the number of lines may vary. See https://github.com/moxiworks/nucleus/pull/839

## JIRA Link
https://moxiworks.atlassian.net/browse/OT-244

![image](https://github.com/moxiworks/widget-factory/assets/3342530/7a569b08-0560-4dff-966a-245b25b0257e)

